### PR TITLE
Fix bug when using arms lore and item disappears

### DIFF
--- a/Data/Scripts/Items/Containers/LootPack.cs
+++ b/Data/Scripts/Items/Containers/LootPack.cs
@@ -101,10 +101,11 @@ namespace Server
 					Item item = entry.Construct( from, luckChance, spawning );
 
 					if ( item != null )
-						LootPackChange.RemoveItem( item, from, level );
-
-					if ( item != null )
 					{
+						LootPackChange.RemoveItem( item, from, level );
+						if (item.Deleted)
+							continue;
+							
 						item = LootPackChange.ChangeItem( item, from, level );
 						NotIdentified.ConfigureItem( item, cont, from );
 						ReagentJar.ConfigureItem( item, cont, from );


### PR DESCRIPTION
This should fix the issue when you use arms lore and the item disappears.  #1 

I've done some testing locally and I haven't seen the issue with this fix yet.