### PR TITLE
Monster players now use the starting gold settings

### DIFF
--- a/Data/Scripts/Mobiles/Civilized/ShardGreeter.cs
+++ b/Data/Scripts/Mobiles/Civilized/ShardGreeter.cs
@@ -513,7 +513,7 @@ namespace Server.Gumps
 				}
 				Server.Items.BaseRace.RemoveMyClothes( m );
 
-				m.AddToBackpack( new Gold( Utility.RandomMinMax(100,150) ) );
+				m.AddToBackpack( new Gold( MyServerSettings.StartingGold() ) );
 
 				switch ( Utility.RandomMinMax( 1, 2 ) )
 				{


### PR DESCRIPTION
Monster players will now generate gold based on the starting gold settings #2.