### PR TITLE
Add Frankenstein's Journal to loot tables

### DIFF
--- a/Data/Scripts/Items/Containers/Loot.cs
+++ b/Data/Scripts/Items/Containers/Loot.cs
@@ -693,7 +693,8 @@ namespace Server
 				typeof( ECrystalAltarDeed ),	typeof( ECrystalBeggarStatueDeed ),		typeof( RunicUndertaker ),
 				typeof( RunicLeatherKit ),		typeof( RunicScales ),					typeof( GolemManual ),
 				typeof( SummonPrison ),			typeof( MagicalWand ),					typeof( MagicalWand ),
-				typeof( BrokenBedDeed ),		typeof( Runebook ),						typeof( RecallRune)
+				typeof( BrokenBedDeed ),		typeof( Runebook ),						typeof( RecallRune),
+				typeof( FrankenJournalInBox )
 			};
 
 		public static Type[] RareItemTypes{ get{ return m_RareItemTypes; } }


### PR DESCRIPTION
Add Frankenstein's Journal as a rare drop in chests.

Fixes #27 