### PR TITLE
Fix bug with text on rare anvils

### DIFF
--- a/Data/Scripts/Trades/Bulk Orders/Rewards/ColoredAnvil.cs
+++ b/Data/Scripts/Trades/Bulk Orders/Rewards/ColoredAnvil.cs
@@ -48,6 +48,9 @@ namespace Server.Items
 			Hue = CraftResources.GetHue(m_Resource);
 		}
 
+		// Override to prevent displaying the styled text on click
+		public override void OnAosSingleClick( Mobile from ) {}
+
 		[Constructable]
 		public RareAnvil() : base( 0xFAF )
 		{


### PR DESCRIPTION
When a rare anvil is single clicked it tries to display the item name as with a regular anvil but since the text is styled it shows the markup instead of the name.

Other rare items do not display a name when clicked, so this change overrides the click functionality to be similar.

Fixes #36