### PR TITLE
fix for the [password command

### DIFF
--- a/Data/Scripts/System/Help/HelpGump.cs
+++ b/Data/Scripts/System/Help/HelpGump.cs
@@ -1723,7 +1723,7 @@ namespace Server.Engines.Help
 				+ "[magicgate - Helps one find the nearest magical gate.<br><br>"
 				+ "[motd - Opens the message of the day.<br><br>"
 				+ "[oriental - Turns on/off the oriental flavor the game provides (see end).<br><br>"
-				+ "[password - Change your account password.<br><br>"
+				+ "[password - Change your account password. Passwords have a limit of 16 characters.<br><br>"
 				+ "[poisons - This changes how poisoned weapons work, which can be for either precise control with special weapon infectious strikes (default) or with hits of a one-handed slashing or piercing weapon.<br><br>"
 				+ "[private - Turns on/off detailed messages of your journey for the town crier and local citizen chatter.<br><br>"
 				+ "[quests - Opens a scroll to show certain quest events.<br><br>"

--- a/Data/Scripts/System/Misc/Accounts.cs
+++ b/Data/Scripts/System/Misc/Accounts.cs
@@ -364,7 +364,7 @@ namespace Server.Misc
 				CommandSystem.Register( "Password", AccessLevel.Player, new CommandEventHandler( Password_OnCommand ) );
 		}
 
-		[Usage( "Password <newPassword> <repeatPassword>" )]
+		[Usage( "Password <newPassword> <repeatPassword>, with a limit of 16 characters." )]
 		[Description( "Changes the password of the commanding players account." )]
 		public static void Password_OnCommand( CommandEventArgs e )
 		{
@@ -393,6 +393,11 @@ namespace Server.Misc
 			{
 				from.SendMessage( "To prevent potential typing mistakes, you must type the password twice. Use the format:" );
 				from.SendMessage( "Password \"(newPassword)\" \"(repeated)\"" );
+				return;
+			}
+			if( e.GetString( 0 ).Length > 16)
+			{
+				from.SendMessage( "The new password must have 16 characters or less." );
 				return;
 			}
 


### PR DESCRIPTION
Adds a check for password length to prevent users from softlocking themselves out of the account, also updates helpgump to display the maximum password limit. 

Solves issue #53 