### PR TITLE
fix bone type on all lich creatures

### DIFF
--- a/Data/Scripts/Mobiles/Humanoids/Sailors/Galleons/PirateLich.cs
+++ b/Data/Scripts/Mobiles/Humanoids/Sailors/Galleons/PirateLich.cs
@@ -83,6 +83,6 @@ namespace Server.Mobiles
 		public override double BreathDamageScalar{ get{ return 0.4; } }
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int Skeletal{ get{ return Utility.Random(3); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 	}
 }

--- a/Data/Scripts/Mobiles/Humanoids/Sailors/Galleons/PirateLichLord.cs
+++ b/Data/Scripts/Mobiles/Humanoids/Sailors/Galleons/PirateLichLord.cs
@@ -88,6 +88,6 @@ namespace Server.Mobiles
 		public override double BreathDamageScalar{ get{ return 0.4; } }
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 	}
 }

--- a/Data/Scripts/Mobiles/Undead/AncientLich.cs
+++ b/Data/Scripts/Mobiles/Undead/AncientLich.cs
@@ -137,7 +137,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 5; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
 		public AncientLich( Serial serial ) : base( serial )
 		{

--- a/Data/Scripts/Mobiles/Undead/DemiLich.cs
+++ b/Data/Scripts/Mobiles/Undead/DemiLich.cs
@@ -181,7 +181,7 @@ namespace Server.Mobiles
 		public override bool ShowFameTitle{ get{ return false; } }
 		public override bool AlwaysAttackable{ get{ return true; } }
 		public override int Skeletal{ get{ return Utility.Random(5); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
         public override int GetAngerSound()
         {

--- a/Data/Scripts/Mobiles/Undead/Lich.cs
+++ b/Data/Scripts/Mobiles/Undead/Lich.cs
@@ -123,7 +123,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 3; } }
 		public override int Skeletal{ get{ return Utility.Random(3); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
 		public Lich( Serial serial ) : base( serial )
 		{

--- a/Data/Scripts/Mobiles/Undead/LichKing.cs
+++ b/Data/Scripts/Mobiles/Undead/LichKing.cs
@@ -144,7 +144,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 5; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
         public override int GetAngerSound()
         {

--- a/Data/Scripts/Mobiles/Undead/LichLord.cs
+++ b/Data/Scripts/Mobiles/Undead/LichLord.cs
@@ -123,7 +123,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 4; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
         public override int GetAngerSound()
         {

--- a/Data/Scripts/Mobiles/Undead/SoulReaper.cs
+++ b/Data/Scripts/Mobiles/Undead/SoulReaper.cs
@@ -100,7 +100,7 @@ namespace Server.Mobiles
 		public override bool ShowFameTitle{ get{ return false; } }
 		public override bool AlwaysAttackable{ get{ return true; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 		public override int Cloths{ get{ return 5; } }
 		public override ClothType ClothType{ get{ return ClothType.Vile; } }
 

--- a/Data/Scripts/Mobiles/Undead/Surtaz.cs
+++ b/Data/Scripts/Mobiles/Undead/Surtaz.cs
@@ -130,7 +130,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 5; } }
 		public override int Skeletal{ get{ return Utility.Random(10); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
         public override int GetAngerSound()
         {

--- a/Data/Scripts/Mobiles/Undead/TitanLich.cs
+++ b/Data/Scripts/Mobiles/Undead/TitanLich.cs
@@ -127,7 +127,7 @@ namespace Server.Mobiles
 		public override bool BleedImmune{ get{ return true; } }
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
 		public override void OnGotMeleeAttack( Mobile attacker )
 		{

--- a/Data/Scripts/Mobiles/Undead/UndeadDruid.cs
+++ b/Data/Scripts/Mobiles/Undead/UndeadDruid.cs
@@ -86,7 +86,7 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Deadly; } }
 		public override int TreasureMapLevel{ get{ return 3; } }
 		public override int Skeletal{ get{ return Utility.Random(3); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
         public override int GetAngerSound()
         {

--- a/Data/Scripts/Mobiles/Undead/Vordo.cs
+++ b/Data/Scripts/Mobiles/Undead/Vordo.cs
@@ -169,7 +169,7 @@ namespace Server.Mobiles
 		public override bool Unprovokable{ get{ return true; } }
 		public override int TreasureMapLevel{ get{ return 4; } }
 		public override int Skeletal{ get{ return Utility.Random(4); } }
-		public override SkeletalType SkeletalType{ get{ return SkeletalType.Xeno; } }
+		public override SkeletalType SkeletalType{ get{ return SkeletalType.Lich; } }
 
 		public override int GetIdleSound()
 		{


### PR DESCRIPTION
Previously, all lich type creatures were dropping pricy Xeno bones when skinned. This change makes them drop Xeno bones. 

Solves issue #41 