### PR TITLE
adds server setting to configure the maximum paralyze duration

### DIFF
--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -987,8 +987,7 @@ namespace Server.Mobiles
 			{
 				Effects.SendLocationEffect( blast1, target.Map, 0x10D3, 30, 10, 0, 0 );
 				target.PlaySound( 0x62D );
-				double webbed = ((double)(this.Fame/200));
-					if ( webbed > 15.0 ){ webbed = 15.0; }
+				double webbed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration : ((double)(this.Fame/200));
 				target.Paralyze( TimeSpan.FromSeconds( webbed ) );
 			}
 			else if ( form == 7 ) // GIANT STONES AND LOGS ------------------------------------------------------------------------------------------
@@ -1272,9 +1271,7 @@ namespace Server.Mobiles
 				Effects.SendLocationEffect( blast5, target.Map, 0x3400, 60, 0xB97, 0 );
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 3;
-
-				double weed = ((double)(this.Fame/200));
-					if ( weed > 15.0 ){ weed = 15.0; }
+				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration : ((double)(this.Fame/200));
 				target.Paralyze( TimeSpan.FromSeconds( weed ) );
 			}
 			else if ( form == 35 ) // SMALL WEED BREATH ---------------------------------------------------------------------------------------------
@@ -1283,8 +1280,7 @@ namespace Server.Mobiles
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 2;
 
-				double weed = ((double)(this.Fame/200));
-					if ( weed > 15.0 ){ weed = 15.0; }
+				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration: ((double)(this.Fame/200));
 				target.Paralyze( TimeSpan.FromSeconds( weed ) );
 			}
 			else if ( form == 36 ) // ACID SPLASH ---------------------------------------------------------------------------------------------------
@@ -1302,7 +1298,8 @@ namespace Server.Mobiles
 				Point3D wrapped = new Point3D( ( target.X ), ( target.Y ), (target.Z+2) );
 				Effects.SendLocationEffect( wrapped, target.Map, 0x23AF, 30, 10, 0, 0 );
 				target.PlaySound( 0x5D2 );
-				target.Paralyze( TimeSpan.FromSeconds( 5.0 ) );
+				double wrap = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration: ((double)(this.Fame/200));
+				target.Paralyze( TimeSpan.FromSeconds( wrap ) );
 			}
 			else if ( form == 38 ) // SMALL STEAM BREATH --------------------------------------------------------------------------------------------
 			{

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -447,7 +447,12 @@ namespace Server
 		public static int S_SpawnMax = 60;
 
 
-
+	// This settings controls the limit in seconds by which you can be paralyzed by a monster. 
+	// The default is 10 seconds. It mainly affects mummies, ants, plants and spiders. Setting it to a
+	// value higher than 10 could mean that the paralyze cooldown is lower than its duration, 
+	// which can lead to frustrating fights as enemies can flee and chain-paralyze a character until they heal 
+	// enough to get back into the fight. 
+		public static double S_paralyzeDuration = 10.0;
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// MERCHANTS //////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1 - adds server setting to configure maximum paralyze duration
2 - lowers default paralyze duration default from 15 to 10 to prevent fleeing creatures from chain-paralyzing characters

solves issue #33 