### PR TITLE
changes alignment trap to give a penalty instead of reversing karma

### DIFF
--- a/Data/Scripts/Items/Traps/HiddenTrap.cs
+++ b/Data/Scripts/Items/Traps/HiddenTrap.cs
@@ -958,13 +958,17 @@ namespace Server.Items
 					}
 					else if ( nTrapType == 25 && m.Karma != 0 && SavingThrow( m, "Magic", true, this ) == false ) // ALIGNMENT TRAP
 					{
-						m.Karma = m.Karma * -1;
-						textSay = "A trap triggered, making your mind warp your morality!";
-						textLog = "a mind warping trap";
-						m.LocalOverheadMessage(MessageType.Emote, 0x916, true, textSay);
+						int KarmaToChange = m.Karma;
+						if (KarmaToChange> 0){
+							KarmaToChange = (int)(KarmaToChange - (KarmaToChange *(0.20)));
+						} else {
+							KarmaToChange = (int)(KarmaToChange + (KarmaToChange *(0.20)));
+						}
+						m.Karma = KarmaToChange;
+						m.LocalOverheadMessage(MessageType.Emote, 0x916, true, "A trap triggered, making your mind warp your morality!");
 						m.FixedParticles( 0x374A, 10, 15, 5028, EffectLayer.Waist );
-						m.PlaySound( 0x1E1 );
-						sTrapType = textLog;
+						m.PlaySound( 0x1E1  );
+						sTrapType = "a mind warping trap";
 					}
 
 					///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
based on discussion that happened in #51 , it was agreed that a short term solution was to make the alignment trap give you a karma penalty instead of straight up inverting it and potentially turning off a couple skills/archetypes like knightship/death knight and sith/priest/jedi stuff. This implementation makes it so that stepping on the tile reduces/increases your karma a bit depending on where it is at, but doesnt cripple your character. 