### PR TITLE
changes 'nox box' to 'Nox Ranger's light Crossbow'

### DIFF
--- a/Data/Scripts/Items/Magical/Artifacts/Main/Artifact_NoxBow.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/Artifact_NoxBow.cs
@@ -11,7 +11,7 @@ namespace Server.Items
         [Constructable]
         public Artifact_NoxBow()
         {
-            Name = "Nox Bow";
+            Name = "Nox Ranger's Light Crossbow";
             Attributes.WeaponDamage = 45;
             Hue = 267;
 			ItemID = 0x13FD;

--- a/Data/Scripts/Quests/Search/SearchBook.cs
+++ b/Data/Scripts/Quests/Search/SearchBook.cs
@@ -449,7 +449,7 @@ namespace Server.Items
 			if ( artifact == arty) { name="Artifact_NightsKiss"; item="Night's Kiss"; } arty++;
 			if ( artifact == arty) { name="Artifact_NordicVikingSword"; item="Nordic Dragon Blade"; } arty++;
 			if ( artifact == arty) { name="Artifact_VampiresRobe"; item="Nosferatu's Robe"; } arty++;
-			if ( artifact == arty) { name="Artifact_NoxBow"; item="Nox Bow"; } arty++;
+			if ( artifact == arty) { name="Artifact_NoxBow"; item="Nox Ranger's Light Croosbow"; } arty++;
 			if ( artifact == arty) { name="Artifact_NoxNightlight"; item="Nox Nightlight"; } arty++;
 			if ( artifact == arty) { name="Artifact_NoxRangersHeavyCrossbow"; item="Nox Ranger's Heavy Crossbow"; } arty++;
 			if ( artifact == arty) { name="Artifact_OblivionsNeedle"; item="Oblivion Needle"; } arty++;


### PR DESCRIPTION
solves issues #89 
With this small change, there will be a heavy and a light crossbow related to the Nox Rangers. 
![image](https://github.com/user-attachments/assets/0f67bc56-d1ea-41d9-9a9b-641267aa785e)
