### PR TITLE
rebalanced stealing coffer value

### DIFF
--- a/Data/Scripts/Quests/Thief/Coffer.cs
+++ b/Data/Scripts/Quests/Thief/Coffer.cs
@@ -99,14 +99,11 @@ namespace Server.Items
 				coffer.Hue = CraftResources.GetHue(coffer.Resource);
 			}
 
-			int money1 = 30;
-			int money2 = 120;
+			double w1 = 500 * (MyServerSettings.GetGoldCutRate() * .01);
+			double w2 = 1000 * (MyServerSettings.GetGoldCutRate() * .01);
 
-			double w1 = money1 * (MyServerSettings.GetGoldCutRate() * .01);
-			double w2 = money2 * (MyServerSettings.GetGoldCutRate() * .01);
-
-			money1 = (int)w1;
-			money2 = (int)w2;
+			int money1 = (int)w1;
+			int money2 = (int)w2;
 
 			coffer.CofferGold = Utility.RandomMinMax( money1, money2 );
 			coffer.CofferRobber = "";


### PR DESCRIPTION
Makes stealing less of a dead skill by increasing the amount of gold available in coffer from 30-120 to 125-250 with a default setting of GetGoldCutRate on the server of 25. 

Stealing is risky. Guards are dangerous. Depending on server settings, dungeon stealable bags are a complete was of time and skill points. This change makes it so that there's a little bit of an incentive to play a thief that can sneak up on a store and get someone else's belongings. 

A thief won't be rich overnight and will risk being caught many times, thus requiring some other ways of dealing with guards (recalling, invis and so on), aswell as general npc hostility. 

Balance wise, not much will change, except that a player using stealing/snooping won't feel scammed out of 250 skill points. 