### PR TITLE
implements skill-based poisoning charge limits and weapon coating.

### DIFF
--- a/Data/Scripts/System/Skills/Poisoning.cs
+++ b/Data/Scripts/System/Skills/Poisoning.cs
@@ -1,3 +1,4 @@
+using Server;
 using System;
 using Server.Targeting;
 using Server.Items;
@@ -130,6 +131,7 @@ namespace Server.SkillHandlers
 					{
 						if ( m_From.CheckTargetSkill( SkillName.Poisoning, m_Target, m_MinSkill, m_MaxSkill ) )
 						{
+							bool maxChargesReached = false;
 							if ( m_Target is Food )
 							{
 								((Food)m_Target).Poison = m_Poison;
@@ -140,11 +142,24 @@ namespace Server.SkillHandlers
 								((BaseBeverage)m_Target).Poison = m_Poison;
 								((BaseBeverage)m_Target).Poisoner = m_From;
 							}
-							else if ( m_Target is BaseWeapon )
+							else if ( m_Target is BaseWeapon && !MySettings.poisoningCharges)
 							{
 								((BaseWeapon)m_Target).Poison = m_Poison;
 								((BaseWeapon)m_Target).PoisonCharges = 18 - (m_Poison.Level * 2);
 							}
+							else if ( m_Target is BaseWeapon && MySettings.poisoningCharges)
+							{
+								// at 125 skill, a weapon can hold 41 poison charges. 
+								int maximumPoisonCharges =  (int)(m_From.Skills[SkillName.Poisoning].Value)/3;
+								((BaseWeapon)m_Target).Poison = m_Poison;
+								// every coating adds from poisoning/10 to poisoning/7 charges. At 125 skill that translates to 12 to 17 charges per potion.
+								int chargesToAdd = Utility.RandomMinMax((int)(m_From.Skills[SkillName.Poisoning].Value)/10,(int)(m_From.Skills[SkillName.Poisoning].Value/7));
+								((BaseWeapon)m_Target).PoisonCharges = ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd > 41 ? 41 : ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd;
+								if (((BaseWeapon)m_Target).PoisonCharges == maximumPoisonCharges)
+								{
+									maxChargesReached = true;
+								}
+							} 
 							else if ( m_Target is FukiyaDarts )
 							{
 								((FukiyaDarts)m_Target).Poison = m_Poison;
@@ -156,9 +171,15 @@ namespace Server.SkillHandlers
 								((Shuriken)m_Target).PoisonCharges = Math.Min( 18 - (m_Poison.Level * 2), ((Shuriken)m_Target).UsesRemaining );
 							}
 
-							m_From.SendLocalizedMessage( 1010517 ); // You apply the poison
-
-							Misc.Titles.AwardKarma( m_From, -20, true );
+							if(maxChargesReached)
+							{
+								m_From.SendMessage(38, "This weapon has as much poison as your skills can handle.");
+							}
+							else 
+							{
+								m_From.SendLocalizedMessage( 1010517 ); // You apply the poison
+								Misc.Titles.AwardKarma( m_From, -20, true );
+							}
 						}
 						else // Failed
 						{

--- a/Data/Scripts/System/Skills/Poisoning.cs
+++ b/Data/Scripts/System/Skills/Poisoning.cs
@@ -154,7 +154,7 @@ namespace Server.SkillHandlers
 								((BaseWeapon)m_Target).Poison = m_Poison;
 								// every coating adds from poisoning/10 to poisoning/7 charges. At 125 skill that translates to 12 to 17 charges per potion.
 								int chargesToAdd = Utility.RandomMinMax((int)(m_From.Skills[SkillName.Poisoning].Value)/10,(int)(m_From.Skills[SkillName.Poisoning].Value/7));
-								((BaseWeapon)m_Target).PoisonCharges = ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd > 41 ? 41 : ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd;
+								((BaseWeapon)m_Target).PoisonCharges = ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd >  maximumPoisonCharges ? maximumPoisonCharges : ((BaseWeapon)m_Target).PoisonCharges + chargesToAdd;
 								if (((BaseWeapon)m_Target).PoisonCharges == maximumPoisonCharges)
 								{
 									maxChargesReached = true;

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -234,7 +234,9 @@ namespace Server
 		public static int S_MinGold = 100;
 		public static int S_MaxGold = 150;
 
-
+	// this changes how the poisoning skill works. If set to true, then character skill will be taken into account instead of poison
+    // level to determine the maximum amount of poison charges a weapon can have, as well as how many charges are applied with each dose. 
+        public static bool poisoningCharges = true;
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
implements #93 

What this change does is add a server setting to add a new form of poisoning to the game, that if set to true will make the maximum amount of poison charges a character can have in a weapon be dependent on their skills with poisoning instead of an arbitrary fixed number based on poison level. It also changes how many charges are added to a weapon to a number based on character skill instead of going automatically to the maximum. 

The aim of this is to make poisoning more enjoyable and less maintenance-heavy for users of the skill. 

If the new server setting is set to false, then the default system stays in place and nothing is changed. 