### PR TITLE
Fix issue with large BOD tareting itself

### DIFF
--- a/Data/Scripts/Trades/Bulk Orders/LargeBOD.cs
+++ b/Data/Scripts/Trades/Bulk Orders/LargeBOD.cs
@@ -202,34 +202,6 @@ namespace Server.Engines.BulkOrders
 							BeginCombine( from );
 					}
 				}
-				else if (o == this)
-				{
-					for ( int i = 0; i < m_Entries.Length; ++i )
-					{
-						if (o is LargeSmithBOD)
-						{
-							SmallSmithBOD SmallBOD = new SmallSmithBOD();
-							SmallBOD.Type = m_Entries[i].Details.Type;
-							SmallBOD.Number = m_Entries[i].Details.Number;
-							SmallBOD.AmountMax = this.AmountMax;
-							SmallBOD.Graphic = m_Entries[i].Details.Graphic;
-							SmallBOD.Material = this.Material;
-							SmallBOD.RequireExceptional = this.RequireExceptional;
-							from.AddToBackpack(SmallBOD);
-						}
-						else if (o is LargeTailorBOD)
-						{
-							SmallTailorBOD SmallBOD = new SmallTailorBOD();
-							SmallBOD.Type = m_Entries[i].Details.Type;
-							SmallBOD.Number = m_Entries[i].Details.Number;
-							SmallBOD.AmountMax = this.AmountMax;
-							SmallBOD.Graphic = m_Entries[i].Details.Graphic;
-							SmallBOD.Material = this.Material;
-							SmallBOD.RequireExceptional = this.RequireExceptional;						
-							from.AddToBackpack(SmallBOD);
-						}
-					}
-				}
 				else
 				{
 					from.SendLocalizedMessage( 1045159 ); // That is not a bulk order.


### PR DESCRIPTION
When you recieve a large BOD, you also receive all the required small BODs required to complete it.  When you target the large BOD, it creates a whole other set of small BODs.

This change will prevent the small BODs from being generated when it is targeted.

Fixes #76