### PR TITLE
restricts skill bonuses to the character skill cap.

### DIFF
--- a/Data/Scripts/System/Misc/AOS.cs
+++ b/Data/Scripts/System/Misc/AOS.cs
@@ -886,7 +886,7 @@ namespace Server
 					m_Mods = new List<SkillMod>();
 
 				SkillMod sk = new DefaultSkillMod( skill, true, bonus );
-				sk.ObeyCap =  true;
+				sk.ObeyCap =  !MySettings.S_itemsOvercapSkills;
 				m.AddSkillMod( sk );
 				m_Mods.Add( sk );
 			}

--- a/Data/Scripts/System/Misc/AOS.cs
+++ b/Data/Scripts/System/Misc/AOS.cs
@@ -886,7 +886,7 @@ namespace Server
 					m_Mods = new List<SkillMod>();
 
 				SkillMod sk = new DefaultSkillMod( skill, true, bonus );
-				sk.ObeyCap = false;
+				sk.ObeyCap =  true;
 				m.AddSkillMod( sk );
 				m_Mods.Add( sk );
 			}

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -346,7 +346,11 @@ namespace Server
 
 		public static int S_TrainMulti = 1;
 
+	// This setting controls whether items with skill bonuses can go past the character skill cap or not. 
+	// if set to true (default) a character will not need a powerscroll to get a skill above 100 with an item giving a bonus to that skill,
+	// if set to false, a character will them need to use a powerscroll in order to get their skill past cap. 
 
+		public static bool S_itemsOvercapSkills = true; 
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change was made to make powerscrolls more desirable and to add a more reliable gold sink to the game. 

It implements #131 