### PR TITLE
Bring TranslocationItem name into compliance with interface naming convention

### DIFF
--- a/Data/Scripts/Items/Misc/Translocation/BagOfSending.cs
+++ b/Data/Scripts/Items/Misc/Translocation/BagOfSending.cs
@@ -15,7 +15,7 @@ namespace Server.Items
 		Red
 	}
 
-	public class BagOfSending : Item, TranslocationItem
+	public class BagOfSending : Item, ITranslocationItem
 	{
 		public static BagOfSendingHue RandomHue()
 		{

--- a/Data/Scripts/Items/Misc/Translocation/BallOfSummoning.cs
+++ b/Data/Scripts/Items/Misc/Translocation/BallOfSummoning.cs
@@ -12,7 +12,7 @@ using Server.Spells.Ninjitsu;
 
 namespace Server.Items
 {
-	public class BallOfSummoning : Item, TranslocationItem
+	public class BallOfSummoning : Item, ITranslocationItem
 	{
 		private int m_Charges;
 		private int m_Recharges;

--- a/Data/Scripts/Items/Misc/Translocation/PowderOfTranslocation.cs
+++ b/Data/Scripts/Items/Misc/Translocation/PowderOfTranslocation.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Items
 {
-	public interface TranslocationItem
+	public interface ITranslocationItem
 	{
 		int Charges{ get; set; }
 		int Recharges{ get; set; }
@@ -61,9 +61,9 @@ namespace Server.Items
 				{
 					from.LocalOverheadMessage( MessageType.Regular, 0x3B2, 1019045 ); // I can't reach that.
 				}
-				else if ( targeted is TranslocationItem )
+				else if ( targeted is ITranslocationItem )
 				{
-					TranslocationItem transItem = (TranslocationItem)targeted;
+					ITranslocationItem transItem = (ITranslocationItem)targeted;
 
 					if ( transItem.Charges >= transItem.MaxCharges )
 					{


### PR DESCRIPTION
I stumbled across this source typo while starting on generating mocks from interfaces. At least eyeballing the list my script generated, it's the only interface in the source code not prefixed with `I`.