### PR TITLE
merchant crate nerf for economical sanity

### DIFF
--- a/Data/Scripts/Trades/Shoppes/MerchantCrate.cs
+++ b/Data/Scripts/Trades/Shoppes/MerchantCrate.cs
@@ -123,7 +123,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				base.OnDoubleClick( from );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 			}
@@ -161,7 +161,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				return base.OnDragDrop( from, dropped );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 				return false;
@@ -171,11 +171,12 @@ namespace Server.Items
                 from.SendMessage("This must be locked down in a house to use!");
 				return false;
 			}
-			else if ( from.Kills > 0 )
+			// merchants cant guess that you are a murderer. This is moronic.
+			/* else if ( from.Kills > 0 )
 			{
                 from.SendMessage("This is useless since no one deals with murderers!");
 				return false;
-			}
+			} */
 
 			if ( !base.OnDragDrop( from, dropped ) )
 				return false;
@@ -198,7 +199,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				return base.OnDragDropInto( from, item, p );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 				return false;
@@ -278,8 +279,8 @@ namespace Server.Items
 		{
 			private MerchantCrate m_Crate;
 
-			//public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromHours( 2.0 ) )
-			public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromMinutes( 1.0 ) )
+			public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromHours( 24.0 ) )
+			//public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromMinutes( 1.0 ) )
 			{
 				m_Crate = crate;
 				Priority = TimerPriority.FiveSeconds;


### PR DESCRIPTION
caps merchant crates at 100k gold and makes them only collect gold every 24 hours, greatly reducing the output in which gold can be generated in the world. 