### PR TITLE
Peace duration toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Data/Logs
 throttle.log
+Backups/*
+network-errors.log

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -7576,15 +7576,14 @@ namespace Server.Mobiles
 				}
 				else
 				{
-					int setTime = Utility.RandomMinMax( 10, 25 );
-					p.PeacedUntil = DateTime.Now + TimeSpan.FromSeconds( setTime );
+					p.PeacedUntil = DateTime.Now + TimeSpan.FromSeconds( MySettings.S_paralyzeDuration );
 					p.SendLocalizedMessage( 500616 ); // You hear lovely music, and forget to continue battling!
 					p.Combatant = null;
 					target.Warmode = false;
 					UndressItem( target, Layer.OneHanded );
 					UndressItem( target, Layer.TwoHanded );
 					BuffInfo.RemoveBuff( p, BuffIcon.PeaceMaking );
-					BuffInfo.AddBuff( p, new BuffInfo( BuffIcon.PeaceMaking, 1063664, TimeSpan.FromSeconds( setTime ), p ) );
+					BuffInfo.AddBuff( p, new BuffInfo( BuffIcon.PeaceMaking, 1063664, TimeSpan.FromSeconds( MySettings.S_paralyzeDuration ), p ) );
 				}
 			}
 

--- a/Data/Scripts/Trades/Shoppes/MerchantCrate.cs
+++ b/Data/Scripts/Trades/Shoppes/MerchantCrate.cs
@@ -123,7 +123,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				base.OnDoubleClick( from );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 			}
@@ -161,7 +161,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				return base.OnDragDrop( from, dropped );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 				return false;
@@ -171,11 +171,12 @@ namespace Server.Items
                 from.SendMessage("This must be locked down in a house to use!");
 				return false;
 			}
-			else if ( from.Kills > 0 )
+			// merchants cant guess that you are a murderer. This is moronic.
+			/* else if ( from.Kills > 0 )
 			{
                 from.SendMessage("This is useless since no one deals with murderers!");
 				return false;
-			}
+			} */
 
 			if ( !base.OnDragDrop( from, dropped ) )
 				return false;
@@ -198,7 +199,7 @@ namespace Server.Items
 			if ( !MySettings.S_MerchantCrates )
 				return base.OnDragDropInto( from, item, p );
 
-			if ( CrateGold >= 500000 )
+			if ( CrateGold >= 100000 )
 			{
                 from.SendMessage("There is too much gold in here. You need to transfer it out first.");
 				return false;
@@ -278,8 +279,8 @@ namespace Server.Items
 		{
 			private MerchantCrate m_Crate;
 
-			//public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromHours( 2.0 ) )
-			public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromMinutes( 1.0 ) )
+			public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromHours( 24.0 ) )
+			//public EmptyTimer( MerchantCrate crate ) : base( TimeSpan.FromMinutes( 1.0 ) )
 			{
 				m_Crate = crate;
 				Priority = TimerPriority.FiveSeconds;

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -467,10 +467,10 @@ namespace Server
 		public static int S_SpawnMax = 60;
 
 
-	// This settings controls the limit in seconds by which you can be paralyzed by a monster. 
-	// The default is 10 seconds. It mainly affects mummies, ants, plants and spiders. Setting it to a
-	// value higher than 10 could mean that the paralyze cooldown is lower than its duration, 
-	// which can lead to frustrating fights as enemies can flee and chain-paralyze a character until they heal 
+	// This settings controls the limit in seconds by which you can be peacefied or paralyzed by a monster. 
+	// The default is 10 seconds. It mainly affects bards, harpies, mummies, ants, plants and spiders. Setting it to a
+	// value higher than 10 could mean that the cooldown is lower than its duration, 
+	// which can lead to frustrating fights as enemies can flee and chain-paralyze or peace a character until they heal 
 	// enough to get back into the fight. 
 		public static double S_paralyzeDuration = 10.0;
 


### PR DESCRIPTION
changes the peacemaking duration cap to be equal to the paralyze duration cap, so harpies and bards are less obnoxious to fight against. 