### PR TITLE
Update WizardStaff.cs to add the Spell Channeling property to marksmanship staves and sceptres.

### DIFF
--- a/Data/Scripts/Items/Weapons/Marksman/WizardStaff.cs
+++ b/Data/Scripts/Items/Weapons/Marksman/WizardStaff.cs
@@ -79,6 +79,7 @@ namespace Server.Items
 			Name = "stave";
 			Weight = 7.0;
 			Layer = Layer.TwoHanded;
+   			Attributes.SpellChanneling = 1;
 		}
 
 		public WizardStaff( Serial serial ) : base( serial )
@@ -169,6 +170,7 @@ namespace Server.Items
 			Weight = 3.0;
 			Layer = Layer.OneHanded;
 			ItemID = Utility.RandomList( 0x0DF2, 0x0DF3, 0x0DF4, 0x0DF5, 0x269D, 0x269E, 0x26BC, 0x26C6, 0x639D, 0x639E, 0x639F, 0x63A0 );
+   			Attributes.SpellChanneling = 1;
 		}
 
 		public WizardStick( Serial serial ) : base( serial )


### PR DESCRIPTION
This should take care of https://github.com/Secrets-of-Sosaria/World/issues/102 but I would appreciate some local testing from those who play characters like this. I've only done some cursory testing locally on my end with a very basic character. It's a very simple change and should just work, but you never know!