### PR TITLE
balance pass on TreasureMapChest.cs

### DIFF
--- a/Data/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Data/Scripts/Items/Containers/TreasureMapChest.cs
@@ -96,31 +96,64 @@ namespace Server.Items
 			ColorHue2 = "FFB400";
 
             // = SCROLL OF TRANCENDENCE
-            if ( level >= 4 && Utility.RandomDouble() > 0.9 )
+            if ( level >= 4 && Utility.RandomDouble() > 0.6 )
                 DropItem(ScrollofTranscendence.CreateRandom(level, level * 5));
             
 			// = ARTIFACTS
-			int artychance = GetPlayerInfo.LuckyPlayerArtifacts( owner.Luck );
-			if ( Utility.Random( 100 ) < ( ( level * 17 ) + artychance ) )
+			if (level >= 7 && Utility.Random(300) < ( ( level * 17 ) + GetPlayerInfo.LuckyPlayerArtifacts( owner.Luck )))
+			{
+				Item arty = Loot.RandomArty();
+				DropItem( arty );
+			}
+			else if (level >= 9 && Utility.Random(200) < ( ( level * 17 ) + GetPlayerInfo.LuckyPlayerArtifacts( owner.Luck )))
 			{
 				Item arty = Loot.RandomArty();
 				DropItem( arty );
 			}
 
             // = SCROLL OF ALACRITY or POWERSCROLL
-            if (level > 1)
+            // higher level chests have a chance of dropping lower level scrolls
+			if (level > 1)
             {
-                if (Utility.RandomDouble() < (0.02 + (level / 200)))
+                if (Utility.RandomDouble() < (0.06 + (level / 200)))
                 {
                     SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
                     DropItem(PowerScroll.CreateRandomNoCraft(5, 5));
+                }
+                else if (Utility.RandomDouble() < 0.095)
+                {
+                    SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
+                    DropItem(new ScrollofAlacrity(WhatS));
+                }
+            } 
+			
+			if (level > 5)
+			{
+				if (Utility.RandomDouble() < (0.04 + (level / 200)))
+                {
+                    SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
+                    DropItem(PowerScroll.CreateRandomNoCraft(5, 10));
+                }
+                else if (Utility.RandomDouble() < 0.085)
+                {
+                    SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
+                    DropItem(new ScrollofAlacrity(WhatS));
+                }
+			}
+			
+			if (level >= 9 )
+			{
+				 if (Utility.RandomDouble() < (0.02 + (level / 200)))
+                {
+                    SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
+                    DropItem(PowerScroll.CreateRandomNoCraft(5, 15));
                 }
                 else if (Utility.RandomDouble() < 0.075)
                 {
                     SkillName WhatS = SpecialScroll.ScrollSkill( 0 );
                     DropItem(new ScrollofAlacrity(WhatS));
                 }
-            }
+			}
 
 			int giveRelics = level;
 			Item relic = Loot.RandomRelic( owner );
@@ -226,7 +259,7 @@ namespace Server.Items
 			{
 				m_Lifted.Add( item );
 
-				if ( 0.1 >= Utility.RandomDouble() ) // 10% chance to spawn a new monster
+				if ( 0.2 >= Utility.RandomDouble() ) // 20% chance to spawn a new monster
 					TreasureMap.Spawn( m_Level, GetWorldLocation(), Map, this );
 			}
 


### PR DESCRIPTION
Currently, treasure hunting offers a somewhat risk-free way of getting large amount of artifacts. 
Even extremely low level chests are very likely to drop them, and since they can be chained, there's a large influx of them in the game, making every other activity pale in comparison for their rewards. 

With that in mind, the following change was implemented:
1 - artifacts will only drop from lvl 3 and above treasure chests, with a small chance for level 3 ones and a slightly larger one from lvl 5 chests. The highest level chests will have about half the chance of getting an artifact as we currently have. 

2 - powerscrolls, scrolls of transcendence and scrolls of alacrity were made more common as drops, varying from 105 to 115 in power. A higher level chest has a chance of dropping multiple lower level scrolls (its a small chance, but its there).

3 - the chance of spawning monsters on taking loot was raised slightly

These changes have the goal of making treasure hunting still desirable, but more in line with other forms of adventuring. Previously, scrolls of alacrity and transcendence were barely found in the game and were often only aqquired by people that were long past the point in which skill gains were a concern, and powerscrolls, while still rare, were also barely noticeable as rewards. In my time on multiverset I did well over 200 treasure chests and found a grand total of 4 power scrolls for skills that none of my characters had any intention of using. These changes hope to amend that by making them a larger part of the cartographer gameplay loop. 

It's also worth noting that crafting power scrolls are not in the list of possible rewards, keeping them as BoD or shop exclusive. 