### PR TITLE
fixes a bug with the spawner for the serpents of chaos/order

### DIFF
--- a/Data/Scripts/Quests/Serpents/BlackrockSerpents.cs
+++ b/Data/Scripts/Quests/Serpents/BlackrockSerpents.cs
@@ -198,4 +198,56 @@ namespace Server.Items
 			int version = reader.ReadInt();
 		}
 	}
+	public class BlackrockSerpentOrderDecoration : Item
+	{
+		[Constructable]
+		public BlackrockSerpentOrderDecoration() : base( 0x25C0 )
+		{
+			Name = "Inert Blackrock Serpent";
+			Weight = 1.0;
+			Hue = 0x96C;
+		}
+
+        public BlackrockSerpentOrderDecoration(Serial serial) : base(serial)
+		{
+		}
+
+		public override void Serialize(GenericWriter writer)
+		{
+			base.Serialize(writer);
+			writer.Write((int) 0);
+		}
+
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize(reader);
+			int version = reader.ReadInt();
+		}
+	}
+	public class BlackrockSerpentChaosDecoration : Item
+	{
+		[Constructable]
+		public BlackrockSerpentChaosDecoration() : base( 0x25C0 )
+		{
+			Name = "Inert Blackrock Serpent";
+			Weight = 1.0;
+			Hue = 0x96C;
+		}
+
+       	public BlackrockSerpentChaosDecoration(Serial serial) : base(serial)
+		{
+		}
+
+		public override void Serialize(GenericWriter writer)
+		{
+			base.Serialize(writer);
+			writer.Write((int) 0);
+		}
+
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize(reader);
+			int version = reader.ReadInt();
+		}
+	}
 }

--- a/Data/Scripts/Quests/Serpents/SerpentSpawners.cs
+++ b/Data/Scripts/Quests/Serpents/SerpentSpawners.cs
@@ -31,7 +31,9 @@ namespace Server.Items
 				BaseCreature monster = new SerpentOfOrder();
 				monster.MoveToWorld( this.Location, this.Map );
 				monster.PlaySound( 0x217 );
-				this.Delete();
+				from.SendMessage( "The Serpent of Order comes forth to challenge you!" );
+				snake.Delete();
+				from.AddToBackpack( new BlackrockSerpentOrderDecoration() );
 			}
 			else
 			{
@@ -74,7 +76,9 @@ namespace Server.Items
 				BaseCreature monster = new SerpentOfChaos();
 				monster.MoveToWorld( this.Location, this.Map );
 				monster.PlaySound( 0x217 );
-				this.Delete();
+				from.SendMessage( "The Serpent of Chaos comes forth to challenge you!" );
+				snake.Delete();
+				from.AddToBackpack( new BlackrockSerpentOrderDecoration() );
 			}
 			else
 			{


### PR DESCRIPTION
When double-clicked, the altar/spawner would disappear and only come back when a [buildworld was run. 
This change modifies the behavior by removing the snakes from the player inventory and adding an identical decoration piece afterwards (one that doesn't trigger the serpent spawn).
solves #144 