### PR TITLE
increases the chances of random notes and citizen rumors being true

### DIFF
--- a/Data/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
+++ b/Data/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
@@ -154,13 +154,13 @@ namespace Server.Mobiles
 			}
 
 			string dungeon = QuestCharacters.SomePlace( "tavern" );
-				if ( Utility.RandomMinMax( 1, 3 ) == 1 ){ dungeon = RandomThings.MadeUpDungeon(); }
+				if ( 40 <= Utility.RandomMinMax( 1, 100 ) ){ dungeon = RandomThings.MadeUpDungeon(); }
 
 			string Clues = QuestCharacters.SomePlace( "tavern" );
-				if ( Utility.RandomMinMax( 1, 3 ) == 1 ){ Clues = RandomThings.MadeUpDungeon(); }
+				if ( 40 <= Utility.RandomMinMax( 1, 100 ) ){ Clues = RandomThings.MadeUpDungeon(); }
 
 			string city = RandomThings.GetRandomCity();
-				if ( Utility.RandomMinMax( 1, 3 ) == 1 ){ city = RandomThings.MadeUpCity(); }
+				if ( 40 <= Utility.RandomMinMax( 1, 100 ) ){ city = RandomThings.MadeUpCity(); }
 
 			string adventurer = Server.Misc.TavernPatrons.Adventurer();
 
@@ -169,9 +169,9 @@ namespace Server.Mobiles
 				item = "the '" + cultInfo.ToTitleCase(item) + "'";
 
 			string locale = Server.Items.SomeRandomNote.GetSpecialItem( relic, 0 );
-				if ( Utility.RandomBool() ) // CITIZENS LIE HALF THE TIME
+				if ( Utility.RandomBool() ) 
 				{
-					if ( Utility.RandomBool() ){ locale = RandomThings.MadeUpDungeon(); }
+					if ( 40 <= Utility.RandomMinMax( 1, 100 ) ){ locale = RandomThings.MadeUpDungeon(); } // 40% chance of being a lie
 					else { locale = QuestCharacters.SomePlace( null ); }
 				}
 

--- a/Data/Scripts/Quests/SomeRandomNote.cs
+++ b/Data/Scripts/Quests/SomeRandomNote.cs
@@ -73,12 +73,11 @@ namespace Server.Items
 
 			ScrollTrue = 1; 
 			string written = "truth";
-			if ( 1 == Utility.RandomMinMax( 0, 1 ) ){ written = "lies"; ScrollTrue = 0; }
+			if ( 40 <= Utility.RandomMinMax( 1, 100 ) ){ written = "lies"; ScrollTrue = 0; } // 40% chance of being a lie, 60% chance of being true;
 
 			int amnt = Utility.RandomMinMax( 1, 49 );
 			int relic = Utility.RandomMinMax( 1, 59 );
 
-			// 50% TRUTH AND 50% LIES /////////////////////
 			if ( written == "lies" )
 			{
 				switch ( amnt )


### PR DESCRIPTION
changes the chance of a rumor wasting the player time from 50% to 40%, so that people might actually want to engage with the system. 

solves #150 