### PR TITLE
adds missing fabric drops to various creatures

### DIFF
--- a/Data/Scripts/Mobiles/Demons/Archfiend.cs
+++ b/Data/Scripts/Mobiles/Demons/Archfiend.cs
@@ -128,6 +128,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(5); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Devil; } }
 
+		public override int Cloths{ get{ return 7; } }
+		public override ClothType ClothType{ get{ return ClothType.Fiendish; } }
+
 		public Archfiend( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Demons/Fiend.cs
+++ b/Data/Scripts/Mobiles/Demons/Fiend.cs
@@ -126,6 +126,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(5); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Devil; } }
 
+		public override int Cloths{ get{ return 3; } }
+		public override ClothType ClothType{ get{ return ClothType.Fiendish; } }
+
 		public Fiend( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Demons/FireDemon.cs
+++ b/Data/Scripts/Mobiles/Demons/FireDemon.cs
@@ -62,6 +62,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(3); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Devil; } }
 
+		public override int Cloths{ get{ return 5; } }
+		public override ClothType ClothType{ get{ return ClothType.Pyre; } }
+
 		public FireDemon( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Goliaths/Ettins/ArcticEttin.cs
+++ b/Data/Scripts/Mobiles/Goliaths/Ettins/ArcticEttin.cs
@@ -69,6 +69,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(2); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Colossal; } }
 
+		public override int Cloths{ get{ return 8; } }
+		public override ClothType ClothType{ get{ return ClothType.Arctic; } }
+
 		public ArcticEttin( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Goliaths/Ogres/ArcticOgreLord.cs
+++ b/Data/Scripts/Mobiles/Goliaths/Ogres/ArcticOgreLord.cs
@@ -92,6 +92,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(4); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Ogre; } }
 
+		public override int Cloths{ get{ return 15; } }
+		public override ClothType ClothType{ get{ return ClothType.Arctic; } }
+
 		public ArcticOgreLord( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Humanoids/MindFlayer.cs
+++ b/Data/Scripts/Mobiles/Humanoids/MindFlayer.cs
@@ -66,6 +66,9 @@ namespace Server.Mobiles
 		public override int Meat{ get{ return 1; } }
 		public override int TreasureMapLevel{ get{ return Core.AOS ? 2 : 0; } }
 
+		public override int Cloths{ get{ return 5; } }
+		public override ClothType ClothType{ get{ return ClothType.Mysterious; } }
+
 		public void SpawnCreature( Mobile target )
 		{
 			Map map = this.Map;

--- a/Data/Scripts/Mobiles/Humanoids/Serpents/FireNaga.cs
+++ b/Data/Scripts/Mobiles/Humanoids/Serpents/FireNaga.cs
@@ -63,6 +63,9 @@ namespace Server.Mobiles
 		public override int Skin{ get{ return Utility.Random(3); } }
 		public override SkinType SkinType{ get{ return SkinType.Snake; } }
 
+		public override int Cloths{ get{ return 8; } }
+		public override ClothType ClothType{ get{ return ClothType.Pyre; } }
+
 		public FireNaga(Serial serial) : base(serial)
 		{
 		}

--- a/Data/Scripts/Mobiles/Insects/Spiders/DreadSpider.cs
+++ b/Data/Scripts/Mobiles/Insects/Spiders/DreadSpider.cs
@@ -72,6 +72,9 @@ namespace Server.Mobiles
 		public override Poison HitPoison{ get{ return Poison.Lethal; } }
 		public override int TreasureMapLevel{ get{ return 3; } }
 
+		public override int Cloths{ get{ return 12; } }
+		public override ClothType ClothType{ get{ return ClothType.Silk; } }
+
 		public DreadSpider( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Insects/Spiders/GiantSpider.cs
+++ b/Data/Scripts/Mobiles/Insects/Spiders/GiantSpider.cs
@@ -72,6 +72,9 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Regular; } }
 		public override Poison HitPoison{ get{ return Poison.Regular; } }
 
+		public override int Cloths{ get{ return 5; } }
+		public override ClothType ClothType{ get{ return ClothType.Silk; } }
+
 		public GiantSpider( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Insects/Spiders/Tarantula.cs
+++ b/Data/Scripts/Mobiles/Insects/Spiders/Tarantula.cs
@@ -91,6 +91,9 @@ namespace Server.Mobiles
 		public override Poison PoisonImmune{ get{ return Poison.Greater; } }
 		public override Poison HitPoison{ get{ return Poison.Greater; } }
 
+		public override int Cloths{ get{ return 8; } }
+		public override ClothType ClothType{ get{ return ClothType.Silk; } }
+
 		#region Pack Animal Methods
 		public override bool OnBeforeDeath()
 		{

--- a/Data/Scripts/Mobiles/Mystical/Angel.cs
+++ b/Data/Scripts/Mobiles/Mystical/Angel.cs
@@ -82,6 +82,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(5); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Mystical; } }
 
+		public override int Cloths{ get{ return 3; } }
+		public override ClothType ClothType{ get{ return ClothType.Divine; } }
+
 		public Angel( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Mystical/Archangel.cs
+++ b/Data/Scripts/Mobiles/Mystical/Archangel.cs
@@ -86,6 +86,9 @@ namespace Server.Mobiles
 		public override int Skeletal{ get{ return Utility.Random(10); } }
 		public override SkeletalType SkeletalType{ get{ return SkeletalType.Mystical; } }
 
+		public override int Cloths{ get{ return 7; } }
+		public override ClothType ClothType{ get{ return ClothType.Divine; } }
+
 		public Archangel( Serial serial ) : base( serial )
 		{
 		}

--- a/Data/Scripts/Mobiles/Unusual/Beholder.cs
+++ b/Data/Scripts/Mobiles/Unusual/Beholder.cs
@@ -102,6 +102,9 @@ namespace Server.Mobiles
 
 		public override int TreasureMapLevel{ get{ return Core.AOS ? 4 : 0; } }
 
+		public override int Cloths{ get{ return 10; } }
+		public override ClothType ClothType{ get{ return ClothType.Mysterious; } }
+
         public override int GetDeathSound()
         {
             return 0x56F;


### PR DESCRIPTION
The following has been added to the base loot pool of the creatures mentioned below (when skinned):

Giant Spiders have a base of 5 silk cloth
Tarantulas have a base of 8 silk cloth
Dread spiders have a base of 12 silk cloth
Arctic Etins have a base of 8 arctic cloth
Arctic Ogre lords have a base of 15 arctic cloth
Fire demons have a base of 5 pyre cloth
Fire Nagas have a base of 8 pyre cloth
Mind flayers have a base of 5 mysterious cloth
Beholders have a base of 10 mysterious cloth
Angels drop a base of 3 divine cloth
Archangels drop a base of 7 divine cloth
fiends drop a base of 3 fiendish cloth
Archfiends drop a base of 7 fiendish cloth


These bases are then influenced by the carver's forensics and tailoring, so better tailors and morticians can get more cloth out of the same creature. 
The formula is base + (forensics/25) + (tailoring/25), so an archfiend skinned by legendary a character with legendary forensics and tailoring would drop 17 fiendish cloth.

The list of creatures that actually drop the fabric was kept small on purpose to not add too much value to an already valuable skill, while still giving tailors the ability to somewhat deterministically hunt for fabric that they might want for their outfits without relying on random treasure drops.

solves #154 