### PR TITLE
hotfix for unkillable snakes of chaos/order

### DIFF
--- a/Data/Scripts/Mobiles/Unique/SerpentOfChaos.cs
+++ b/Data/Scripts/Mobiles/Unique/SerpentOfChaos.cs
@@ -78,7 +78,8 @@ namespace Server.Mobiles
 				if ( m is PlayerMobile && !m.Blessed )
 				{
 					Item rock = m.Backpack.FindItemByType( typeof ( BlackrockSerpentChaos ) );
-					if ( rock != null )
+					Item rockDeco = m.Backpack.FindItemByType( typeof ( BlackrockSerpentChaosDecoration ) );
+					if ( rock != null || rockDeco != null )
 					{
 						CanDie = 1;
 						winner = m;

--- a/Data/Scripts/Mobiles/Unique/SerpentOfOrder.cs
+++ b/Data/Scripts/Mobiles/Unique/SerpentOfOrder.cs
@@ -83,7 +83,8 @@ namespace Server.Mobiles
 				if ( m is PlayerMobile && !m.Blessed )
 				{
 					Item rock = m.Backpack.FindItemByType( typeof ( BlackrockSerpentOrder ) );
-					if ( rock != null )
+					Item rockDeco = m.Backpack.FindItemByType( typeof ( BlackrockSerpentOrderDecoration ) );
+					if ( rock != null || rockDeco != null )
 					{
 						CanDie = 1;
 						winner = m;


### PR DESCRIPTION
adds a check for the serpents of order/chaos to make them killable again