### PR TITLE
stealing box rebalance

### DIFF
--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -297,8 +297,7 @@ namespace Server
 
 		public static bool S_DecoArtySteal = false;
 
-	// If set to true, then characters will only get lucrative items from a pedestal bag/box once every couple
-	// of days.
+	// If set to true, then characters will not receive artifacts from stealable boxes in dungeons. 
 
 		public static bool S_PedStealThrottle = true;
 


### PR DESCRIPTION
- rebalances the amount of gold obtainable by a stealable box
- changes the S_PedStealThrottle setting to only control if players are able to get artifacts from boxes
- adds a skill check for poisoning to give an expert poisoner a chance to avoid being poisoned by a trap
- removes the artificial time gate in stealing, boxes now no longer have a magical internal clock that controls how much fun you are allowed to have with your thieves. 


the goal of these changes is to make stealing a viable option for characters that want to invest in them, with a toggle that can prevent artifact-farming from very lucky thieves. 