### PR TITLE
tamed animal / follower behavior update

### DIFF
--- a/Data/Scripts/Mobiles/Base/Behavior.cs
+++ b/Data/Scripts/Mobiles/Base/Behavior.cs
@@ -7112,6 +7112,7 @@ namespace Server.Mobiles
 				case OrderType.Stop:
 				m_Mobile.ControlMaster.RevealingAction();
 				m_Mobile.Home = m_Mobile.Location;
+				m_Mobile.RangeHome = 5;
 				m_Mobile.CurrentSpeed = m_Mobile.PassiveSpeed;
 				m_Mobile.PlaySound( m_Mobile.GetIdleSound() );
 				m_Mobile.Warmode = false;
@@ -7142,8 +7143,10 @@ namespace Server.Mobiles
 		{
 			m_Mobile.DebugSay( "I have no order" );
 
-			WalkRandomInHome( 3, 2, 1 );
-
+			if ( Utility.RandomMinMax( 1, 10 ) > 9 )
+            {
+				WalkRandomInHome( 3, 2, 1 );
+	        }
 			if( m_Mobile.Combatant != null && !m_Mobile.Combatant.Deleted && m_Mobile.Combatant.Alive && !m_Mobile.Combatant.IsDeadBondedPet )
 			{
 				m_Mobile.Warmode = true;
@@ -7787,15 +7790,15 @@ namespace Server.Mobiles
 				return true;
 
 			m_Mobile.DebugSay( "My master told me to stop." );
-
-			m_Mobile.Direction = m_Mobile.GetDirectionTo( m_Mobile.ControlMaster );
-			m_Mobile.Home = m_Mobile.Location;
-
 			m_Mobile.ControlTarget = null;
 
 			if( Core.ML )
 			{
-				WalkRandomInHome( 3, 2, 1 );
+				if ( Utility.RandomMinMax( 1, 10 ) > 8 )
+				{
+					m_Mobile.Direction = (Direction)Utility.Random( 8 );
+					WalkRandomInHome( 3, 2, 1 );
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Problem:  'all stop' makes creatures head south and directionally glitch out, also minor glitch when they have no order and bounce around

Fix:
- limits them to roam 5 spaces from their home:   m_Mobile.RangeHome = 5;

- I put WalkRandomInHome inside a random if statement so it happens less frequently (looks more natural), this applies to 'all stop' and when they have no order

- Line 7791 and 7792 are unintentionally causing issues, each time this runs it will update the 'home' location and cause it to drift off, luckily it is already set on line 7114 in the OrderType.Stop handler.

My small group of friends is running this change with no issues so far for a few days