### PR TITLE
Crash when using Herbal Healing potion on out of range follower

### DIFF
--- a/Data/Scripts/System/Misc/BuffIcons.cs
+++ b/Data/Scripts/System/Misc/BuffIcons.cs
@@ -162,33 +162,38 @@ namespace Server
 
 		public static void CleanupIcons( Mobile m, bool onlyParalyzed )
 		{
+			if (m == null)
+				return;
 			if ( !onlyParalyzed )
 			{
-				Item orb = m.Backpack.FindItemByType( typeof ( SoulOrb ) );
-					if ( orb == null )
-						BuffInfo.RemoveBuff( m, BuffIcon.Resurrection );
-					else
-						BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.Resurrection, 1063626, true ) );
+				if (m.Backpack != null)
+				{
+					Item orb = m.Backpack.FindItemByType( typeof ( SoulOrb ) );
+						if ( orb == null )
+							BuffInfo.RemoveBuff( m, BuffIcon.Resurrection );
+						else
+							BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.Resurrection, 1063626, true ) );
 
-				Item gem = m.Backpack.FindItemByType( typeof ( GemImmortality ) );
-					if ( gem == null )
-						BuffInfo.RemoveBuff( m, BuffIcon.GemImmortality );
-					else
-						BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.GemImmortality, 1063658, true ) );
+					Item gem = m.Backpack.FindItemByType( typeof ( GemImmortality ) );
+						if ( gem == null )
+							BuffInfo.RemoveBuff( m, BuffIcon.GemImmortality );
+						else
+							BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.GemImmortality, 1063658, true ) );
 
-				Item shard = m.Backpack.FindItemByType( typeof ( JewelImmortality ) );
-					if ( shard == null )
-						BuffInfo.RemoveBuff( m, BuffIcon.WithstandDeath );
-					else
-						BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.WithstandDeath, 1063656, true ) );
+					Item shard = m.Backpack.FindItemByType( typeof ( JewelImmortality ) );
+						if ( shard == null )
+							BuffInfo.RemoveBuff( m, BuffIcon.WithstandDeath );
+						else
+							BuffInfo.AddBuff( m, new BuffInfo( BuffIcon.WithstandDeath, 1063656, true ) );
 
-				Item enchant = m.Backpack.FindItemByType( typeof ( EnchantSpellStone ) );
-					if ( enchant == null )
-						BuffInfo.RemoveBuff( m, BuffIcon.Enchant );
+					Item enchant = m.Backpack.FindItemByType( typeof ( EnchantSpellStone ) );
+						if ( enchant == null )
+							BuffInfo.RemoveBuff( m, BuffIcon.Enchant );
 
-				Item enchanted = m.Backpack.FindItemByType( typeof ( ResearchEnchantStone ) );
-					if ( enchanted == null )
-						BuffInfo.RemoveBuff( m, BuffIcon.EnchantWeapon );
+					Item enchanted = m.Backpack.FindItemByType( typeof ( ResearchEnchantStone ) );
+						if ( enchanted == null )
+							BuffInfo.RemoveBuff( m, BuffIcon.EnchantWeapon );
+				}
 
 				if ( !TransformationSpellHelper.UnderTransformation( m ) )
 				{


### PR DESCRIPTION
Warning! This will crash the server if you try it before this fix.

Repro: tame an animal, say 'all stay', walk away till you are maybe 5-6 steps, not sure exactly when this happens. then use a herbal healing potion, server will crash.

Reason: The function checks a bunch of things to see if it can cure some statuses or if the buff can fall off, but basically the m.Backpack ends up being null when something is too far from you

Fix: check that the backpack is not null prior to looking in it, this method only ignores the backpack related checks when the backpack is null, it will still check all the other elements. Also ignore the entire function when m is null (this probably should never be the case but just in case)

I have been running this fix for a few days on my small server with a couple friends.