### PR TITLE
adds spell channeling to default properties of wizard staffs 

### DIFF
--- a/Data/Scripts/System/Misc/ItemSales.cs
+++ b/Data/Scripts/System/Misc/ItemSales.cs
@@ -233,7 +233,8 @@ namespace Server
 				 || item is ThrowingGloves
 				 || item is WizardWand
 				 || item is PugilistGloves
-				 || item is PugilistGlove ){} else
+				 || item is PugilistGlove
+				 || item is WizardStaff ){} else
 				price +=		((BaseWeapon)item).Attributes.SpellChanneling * 200;
 
 				price +=		((BaseWeapon)item).Attributes.DefendChance * 10;


### PR DESCRIPTION
adds spell channeling to the list of default item properties of wizard staffs to fix sale price as reported on #172 