### PR TITLE
Add project files to support compiling via "dotnet build" on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Data/Logs
+Data/System/Source/obj
 throttle.log

--- a/Data/System/Source/COMPILE-README.md
+++ b/Data/System/Source/COMPILE-README.md
@@ -1,0 +1,23 @@
+Simple guide for compiling `World.exe` based on system.
+
+## Compiling on Windows
+
+Ensure [.NET Framework 4.0](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net40) is installed.
+
+* Launch `PowerShell` via the Start Menu
+* Navigate to the SoS repo's `Data\System` directory
+
+```
+C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc /optimize /unsafe /t:exe /out:World.exe /win32icon:Source\icon.ico /d:NEWTIMERS /d:NEWPARENT /recurse:Source\*.cs
+```
+
+## Compiling on macOS
+
+Ensure [dotnet](https://formulae.brew.sh/formula/dotnet) is installed via [Homebrew](https://brew.sh/).
+
+* Launch `Terminal.app` via Spotlight
+* Navigate to the SoS repo's `Data\System\Source` directory
+
+```
+dotnet build
+```

--- a/Data/System/Source/README
+++ b/Data/System/Source/README
@@ -1,3 +1,0 @@
-To compile the source, use powershell and go into the Server directory and then run the below command:
-
-C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc /optimize /unsafe /t:exe /out:World.exe /win32icon:Source\icon.ico /d:NEWTIMERS /d:NEWPARENT /recurse:*.cs

--- a/Data/System/Source/Source.csproj
+++ b/Data/System/Source/Source.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>World</AssemblyName>
-    <OutputPath>../../../</OutputPath>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>

--- a/Data/System/Source/Source.csproj
+++ b/Data/System/Source/Source.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>World</AssemblyName>
+    <OutputPath>../../../</OutputPath>
+    <ApplicationIcon>icon.ico</ApplicationIcon>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeSymbolsInSingleFile>true</IncludeSymbolsInSingleFile>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <TargetFramework>net4.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>preview</LangVersion>
+    <Deterministic>false</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR adds a project file and some basic steps within new [COMPILE-README.md](https://github.com/Secrets-of-Sosaria/World/blob/3fb423d071731aed28a801c0a33e9fa8cf25c830/Data/System/Source/COMPILE-README.md) file to build the server binary on macOS. This may be useful for those who want to make tweaks to their forked copy of the repo without needing a Windows machine to compile or for those who don't dev on their Windows machine.

⚠️ Windows machine is still required to **run** the binary. This merely adds support for devs who prefer macOS.

> [!NOTE]
> I'm providing these changes with no expectation that they are merged.
> I figured I'd share what I've tweaked for my home server in case this project can benefit from it.