### PR TITLE
Restore optional tool use from backpack via new MySettings variables

### DIFF
--- a/Data/Scripts/Items/Trades/BaseHarvestTool.cs
+++ b/Data/Scripts/Items/Trades/BaseHarvestTool.cs
@@ -182,10 +182,18 @@ namespace Server.Items
 
 		public override void OnDoubleClick( Mobile from )
 		{
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			{
 				HarvestSystem.BeginHarvesting( from, this );
-			else
-				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+			} 
+			else 
+			{	
+				int localizedMessageId = MySettings.S_AllowBackpackHarvestTool 
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 502641; // You must equip this item to use it.
+				
+				from.SendLocalizedMessage( localizedMessageId ); 
+			}
 		}
 
 		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )

--- a/Data/Scripts/Items/Trades/BaseHarvestTool.cs
+++ b/Data/Scripts/Items/Trades/BaseHarvestTool.cs
@@ -182,7 +182,7 @@ namespace Server.Items
 
 		public override void OnDoubleClick( Mobile from )
 		{
-			if ( Parent == from )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
 				HarvestSystem.BeginHarvesting( from, this );
 			else
 				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.

--- a/Data/Scripts/Items/Trades/BaseTool.cs
+++ b/Data/Scripts/Items/Trades/BaseTool.cs
@@ -210,7 +210,7 @@ namespace Server.Items
 			{ 
 				CaptchaGump.sendCaptcha(from, BaseTool.OnDoubleClickRedirected, this);
 			}
-			else if ( Parent == from )
+			else if ( Parent == from || ( MySettings.S_AllowBackpackCraftTool && this.IsChildOf(from.Backpack) ) )
 			{
 				CraftSystem system = this.CraftSystem;
 
@@ -242,7 +242,7 @@ namespace Server.Items
 
 			BaseTool tool = (BaseTool)o;
 
-			if ( tool.Parent == from )
+			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
 			{
 				CraftSystem system = tool.CraftSystem;
 

--- a/Data/Scripts/Items/Trades/BaseTool.cs
+++ b/Data/Scripts/Items/Trades/BaseTool.cs
@@ -231,7 +231,11 @@ namespace Server.Items
 			}
 			else
 			{
-				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+				if (MySettings.S_AllowBackpackCraftTool) {
+					from.SendLocalizedMessage( 1042004 ); // That must be equipped or in your pack to use it.
+				} else {
+					from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+				}
 			}
 		}
 
@@ -261,7 +265,11 @@ namespace Server.Items
 			}
 			else
 			{
-				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+				int localizedMessageId = MySettings.S_AllowBackpackCraftTool
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 502641; // You must equip this item to use it.
+				
+				from.SendLocalizedMessage( localizedMessageId ); 
 			}
 		}
 

--- a/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
+++ b/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
@@ -97,7 +97,7 @@ namespace Server.Items
 			if ( HarvestSystem == null || Deleted )
 				return;
 
-			if ( Parent == from )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
 				HarvestSystem.BeginHarvesting( from, this );
 			else
 				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.

--- a/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
+++ b/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
@@ -97,10 +97,18 @@ namespace Server.Items
 			if ( HarvestSystem == null || Deleted )
 				return;
 
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			{
 				HarvestSystem.BeginHarvesting( from, this );
-			else
-				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+			} 
+			else 
+			{	
+				int localizedMessageId = MySettings.S_AllowBackpackHarvestTool 
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 502641; // You must equip this item to use it.
+				
+				from.SendLocalizedMessage( localizedMessageId ); 
+			}
 		}
 
 		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )

--- a/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
+++ b/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
@@ -65,10 +65,18 @@ namespace Server.Items
 			if ( HarvestSystem == null )
 				return;
 
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			{
 				HarvestSystem.BeginHarvesting( from, this );
-			else
-				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
+			} 
+			else 
+			{	
+				int localizedMessageId = MySettings.S_AllowBackpackHarvestTool 
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 502641; // You must equip this item to use it.
+				
+				from.SendLocalizedMessage( localizedMessageId ); 
+			}
 		}
 
 		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )

--- a/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
+++ b/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
@@ -65,7 +65,7 @@ namespace Server.Items
 			if ( HarvestSystem == null )
 				return;
 
-			if ( Parent == from )
+			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) )
 				HarvestSystem.BeginHarvesting( from, this );
 			else
 				from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.

--- a/Data/Scripts/Trades/Core/CraftGump.cs
+++ b/Data/Scripts/Trades/Core/CraftGump.cs
@@ -48,7 +48,7 @@ namespace Server.Engines.Craft
 			from.CloseGump( typeof( CraftGump ) );
 			from.CloseGump( typeof( CraftGumpItem ) );
 
-			if ( tool.Parent == from )
+			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
 			{
 				AddPage( 0 );
 

--- a/Data/Scripts/Trades/Core/CraftGumpItem.cs
+++ b/Data/Scripts/Trades/Core/CraftGumpItem.cs
@@ -36,7 +36,7 @@ namespace Server.Engines.Craft
 
 			from.CloseGump( typeof( CraftGump ) );
 			from.CloseGump( typeof( CraftGumpItem ) );
-			if ( tool.Parent == from )
+			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
 			{
 				AddPage( 0 );
 				AddImage(0, 0, craftSystem.GumpImage, Server.Misc.PlayerSettings.GetGumpHue( from ));

--- a/Data/System/CFG/cliloc.cfg
+++ b/Data/System/CFG/cliloc.cfg
@@ -22595,7 +22595,7 @@
 1042001	That must be in your pack for you to use it.
 1042002	You combine the berry and the flour into the tribal paint worn by the savages.
 1042003	You don't have the cooking skill to create the body paint.
-1042004	That must be in your pack for you to use it.
+1042004 That must be equipped or in your pack to use it.
 1042005	You combine the berry and the flour into the tribal paint worn by the savages.
 1042006	You don't have the cooking skill to create the body paint.
 1042007	Placement cancelled

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -394,6 +394,13 @@ namespace Server
 
 		public static bool S_AllowMacroResources = false;
 
+	// If false, then characters will need to have the appropriate tool equipped to craft.
+		
+		public static bool S_AllowBackpackCraftTool = false;
+
+	// If false, then characters will need to have the appropriate tool equipped to gather resources.
+		
+		public static bool S_AllowBackpackHarvestTool = false;
 
 
 


### PR DESCRIPTION
This PR restores the original pre-SoS ability from _Adventures of Akalabeth_ to use basic crafting and harvesting tools from the backpack without equipping them.

This is an **optional** setting in which the default respects the changes to tool use in _Secrets of Sosaria_.

The new settings can be found in `Info/Scripts/Settings.cs`.

```cs
// If false, then characters will need to have the appropriate tool equipped to craft.
		
    public static bool S_AllowBackpackCraftTool = false;

// If false, then characters will need to have the appropriate tool equipped to gather resources.
		
    public static bool S_AllowBackpackHarvestTool = false;
```

There's also a change to message ID `1042004` within `Data\System\CFG\cliloc.cfg` which was previously unused and identical to `1042001`.

    1042004 That must be equipped or in your pack to use it.

This ID is used if either `MySettings.S_AllowBackpackCraftTool` or `MySettings.S_AllowBackpackHarvestTool` is set to true for each respective tool type.

> [!NOTE]
> I'm providing these changes with no expectation that they are merged.
> I figured I'd share what I've tweaked for my home server in case this project can benefit from it.