### PR TITLE
Fix issue with SmallTailorBOD intermittently not creating a deed

### DIFF
--- a/Data/Scripts/Trades/Bulk Orders/SmallTailorBOD.cs
+++ b/Data/Scripts/Trades/Bulk Orders/SmallTailorBOD.cs
@@ -120,7 +120,7 @@ namespace Server.Engines.BulkOrders
 
 				bool reqExceptional = ( excChance > Utility.RandomDouble() );
 
-				CraftSystem system = DefLeatherworking.CraftSystem;
+				CraftSystem system = useMaterials ? DefLeatherworking.CraftSystem : DefTailoring.CraftSystem;
 
 				List<SmallBulkEntry> validEntries = new List<SmallBulkEntry>();
 


### PR DESCRIPTION
This PR fixes an intermittent issue with obtaining Tailoring BODs due to inclusion of a new leatherworking system in _Secrets of Sosaria_.

`DefLeatherworking.CraftSystem` was always being used, irrespective of the `useMaterials` roll outcome which determined whether to use cloth or leather.

As a result, when cloth was picked (50% of the time), it would fail to find an appropriate item that could be crafted, and the gump wouldn't appear as the deed was never created.

Now, the appropriate craft system is picked based on material and Tailor NPCs now always provide a BOD without fail.

Fixes #182.

> [!NOTE]
> I'm providing these changes with no expectation that they are merged.
> I figured I'd share what I've tweaked for my home server in case this project can benefit from it.