### PR TITLE
Prevent consuming shoppe resources beyond max

### DIFF
--- a/Data/Scripts/Trades/Shoppes/BaseShoppe.cs
+++ b/Data/Scripts/Trades/Shoppes/BaseShoppe.cs
@@ -353,12 +353,24 @@ namespace Server.Items
 				}
 				else
 				{
+					int remainingSpace = 5000 - ShoppeResources;
+
+                    // Prevent consuming dropped resources beyond shoppe maximum
+                    if ( dropped.Amount > remainingSpace )
+                    {
+                        from.SendMessage( "You can only add " + remainingSpace + " more resources." );
+                        return false;
+                    }
+                    
 					ShoppeResources = ShoppeResources + dropped.Amount;
-					if ( ShoppeResources >= 5000 )
-					{
-						ShoppeResources = 5000;
-						from.SendMessage( "You add more resources but now your shoppe is full." );
-					}
+
+                    from.SendMessage( "You add " + dropped.Amount + " resources to your shoppe." );
+
+                    if ( ShoppeResources == 5000 )
+                    {
+                        from.SendMessage( "Your shoppe is now full of resources." );
+                    }
+
 					from.SendSound( 0x42 );
 					dropped.Delete();
 					return true;


### PR DESCRIPTION
Previously, any resources dropped onto a shoppe would be fully consumed. This included dropping a quantity above the maximum of 5000.

This PR adds a check to ensure the amount being dropped does not exceed the remaining space for shoppe resources, canceling the transfer and returning the items if it does.

Either way, players need to carefully select their quantity being dropped, so this at least prevents lost resources.

A better solution would be to fill the shoppe up to allowable max and return the remainder, but this quick fix at least prevents the pain point of losing thousands of resources.

> [!NOTE]
> I'm providing these changes with no expectation that they are merged.
> I figured I'd share what I've tweaked for my home server in case this project can benefit from it.