### PR TITLE
Koper's taming skill gain when pets fight

### DIFF
--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -31,8 +31,8 @@ namespace Server.Custom.KoperPets
 
         public static void TryGainHerdingSkill(Mobile owner)
         {
-            if (owner == null || !owner.Alive)
-                return; // No skill gain for dead players
+            if (owner == null || !owner.Alive || !MyServerSettings.KoperPets())
+                return; // No skill gain for dead players/system disabled
 
             // Check if the player is on cooldown
             if (_cooldowns.ContainsKey(owner) && DateTime.UtcNow < _cooldowns[owner])
@@ -61,8 +61,10 @@ namespace Server.Custom.KoperPets
                 owner.Skills[SkillName.Herding].Base += skillGain;
 
                 // Select a random message for variety
-                owner.SendMessage(SuccessMessages[Utility.Random(SuccessMessages.Length)]);
-
+                if (MyServerSettings.KoperPetsImmersive()) 
+                {
+                    owner.SendMessage(SuccessMessages[Utility.Random(SuccessMessages.Length)]);
+                }
                 // Start cooldown timer
                 _cooldowns[owner] = DateTime.UtcNow + CooldownTime;
             }

--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -8,7 +8,7 @@ namespace Server.Custom.KoperPets
     public static class KoperHerdingGain
     {
         private static readonly Dictionary<Mobile, DateTime> _cooldowns = new Dictionary<Mobile, DateTime>();
-        private static readonly TimeSpan CooldownTime = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); // 60-second cooldown
+        private static readonly TimeSpan CooldownTime = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); // 20-second cooldown
 
         private static readonly string[] SuccessMessages = new string[]
         {

--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -49,9 +49,9 @@ namespace Server.Custom.KoperPets
 
             // Determine gain chance and amount based on skill level
             if (herdingMultiplier <= 0) herdingMultiplier = 1.0; // Ensure valid value
-            if (herdingSkill <= 30.0) { gainChance = 0.20 * herdingMultiplier; minGain = 0.1; maxGain = 0.3; }
-            else if (herdingSkill <= 50.0) { gainChance = 0.15 * herdingMultiplier; minGain = 0.1; maxGain = 0.2; }
-            else if (herdingSkill <= 70.0) { gainChance = 0.10 * herdingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            if (herdingSkill <= 30.0) { gainChance = 0.20 * herdingMultiplier; minGain = 0.1; maxGain = 1.0; }
+            else if (herdingSkill <= 50.0) { gainChance = 0.15 * herdingMultiplier; minGain = 0.1; maxGain = 0.5; }
+            else if (herdingSkill <= 70.0) { gainChance = 0.10 * herdingMultiplier; minGain = 0.1; maxGain = 0.2; }
             else if (herdingSkill < 100.0) { gainChance = 0.05 * herdingMultiplier; minGain = 0.1; maxGain = 0.1; }
             else return; // No gain if at max skill
 

--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+
+namespace Server.Custom.KoperPets
+{
+    public static class KoperHerdingGain
+    {
+        private static readonly Dictionary<Mobile, DateTime> _cooldowns = new Dictionary<Mobile, DateTime>();
+        private static readonly TimeSpan CooldownTime = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); // 60-second cooldown
+
+        private static readonly string[] SuccessMessages = new string[]
+        {
+            "You feel more confident in guiding animals.",
+            "Your understanding of animal behavior improves.",
+            "You refine your ability to control creatures.",
+            "Your herding instincts grow stronger.",
+            "You sense a deeper connection with the animals.",
+            "You observe the subtle body language of the herd.",
+            "The creatures seem to respond to your commands more easily.",
+            "You learn to anticipate the movements of the animals.",
+            "Your patience with the herd pays off.",
+            "You develop a rhythm in directing the animals.",
+            "The bond between you and your animals strengthens.",
+            "You notice an improvement in how quickly animals obey you.",
+            "You gain insight into the instincts of the creatures you guide.",
+            "You master a new technique in controlling stubborn animals.",
+            "Your steady guidance makes the animals trust you more."
+        };
+
+        public static void TryGainHerdingSkill(Mobile owner)
+        {
+            if (owner == null || !owner.Alive)
+                return; // No skill gain for dead players
+
+            // Check if the player is on cooldown
+            if (_cooldowns.ContainsKey(owner) && DateTime.UtcNow < _cooldowns[owner])
+            {
+                return; // Cooldown is active, exit without giving skill
+            }
+
+            double herdingSkill = owner.Skills[SkillName.Herding].Base;
+            double gainChance;
+            double minGain;
+            double maxGain;
+            double herdingMultiplier = MyServerSettings.KoperHerdingChance();
+
+
+            // Determine gain chance and amount based on skill level
+            if (herdingMultiplier <= 0) herdingMultiplier = 1.0; // Ensure valid value
+            if (herdingSkill <= 30.0) { gainChance = 0.20 * herdingMultiplier; minGain = 0.1; maxGain = 0.3; }
+            else if (herdingSkill <= 50.0) { gainChance = 0.15 * herdingMultiplier; minGain = 0.1; maxGain = 0.2; }
+            else if (herdingSkill <= 70.0) { gainChance = 0.10 * herdingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            else if (herdingSkill < 100.0) { gainChance = 0.05 * herdingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            else return; // No gain if at max skill
+
+            if (Utility.RandomDouble() <= gainChance)
+            {
+                double skillGain = Utility.RandomDouble() * (maxGain - minGain) + minGain;
+                owner.Skills[SkillName.Herding].Base += skillGain;
+
+                // Select a random message for variety
+                owner.SendMessage(SuccessMessages[Utility.Random(SuccessMessages.Length)]);
+
+                // Start cooldown timer
+                _cooldowns[owner] = DateTime.UtcNow + CooldownTime;
+            }
+        }
+    }
+}

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+using Server.Items;
+using Server.Network;
+
+namespace Server.Custom.KoperPets
+{
+    public static class PetTamingSkillGain
+    {
+        // Dictionary to track cooldowns (PlayerMobile -> Last Taming Gain Time)
+        private static Dictionary<PlayerMobile, DateTime> _tamingCooldowns = new Dictionary<PlayerMobile, DateTime>();
+
+        private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(60); //  Set cooldown time (60 Seconds default)
+
+        private static readonly string[] TamingMessages = new string[]
+        {
+            "I feel closer to you, {0}!",
+            "We fight as one, {0}!",
+            "I trust you more, {0}.",
+            "Your guidance makes me stronger, {0}.",
+            "I will follow you anywhere, {0}.",
+            "I understand you better now, {0}!",
+            "You lead, I follow, {0}.",
+            "You are a worthy master, {0}!",
+            "Our bond grows, {0}!",
+            "Through battle, we become one, {0}.",
+            "I stand by your side, {0}.",
+            "I am learning from you, {0}.",
+            "You are my trusted master, {0}.",
+            "This battle strengthens our bond, {0}!",
+            "I heed your call, {0}.",
+            "I will fight for you always, {0}.",
+            "I am becoming stronger with you, {0}.",
+            "Together, we are unstoppable, {0}!"
+        };
+
+        private static readonly string[] BattleCries = new string[]
+        {
+            "For my master!",
+            "You will not harm {0}!",
+            "I will defend you, {0}, with my life!",
+            "Back away from {0}, or suffer my wrath!",
+            "I shall tear you apart!",
+            "You dare threaten my master?!",
+            "Face my fury!",
+            "I'll rip you to shreds!",
+            "Mess with {0}, and you answer to me!",
+            "Prepare to meet your end!",
+            "I fight for you, {0}!",
+            "Together, we are unstoppable!",
+            "I will never abandon you, {0}!",
+            "By your side, always!",
+            "For honor and for {0}!",
+            "With you, I fear nothing!",
+            "We've trained for this moment!",
+            "You lead, and I shall follow!",
+            "Nothing shall break our bond!",
+            "We fight as one!",
+            "You picked the wrong fight!",
+            "I'll make you regret that!",
+            "You're no match for me!",
+            "Let's see what you're made of!",
+            "I'll bite harder than you can handle!",
+            "I eat weaklings like you for breakfast!",
+            "You will fall before me!",
+            "I'll crush your bones!",
+            "Tremble before my might!",
+            "You will learn to fear me!"
+        };
+
+        public static void TryTamingGain(BaseCreature pet, Mobile target)
+        {
+            if (pet == null || target == null)
+                return;
+
+            PlayerMobile owner = pet.ControlMaster as PlayerMobile;
+            if (owner == null)
+                return;
+
+            // Check if player is on cooldown
+            DateTime lastGainTime;
+            if (_tamingCooldowns.TryGetValue(owner, out lastGainTime))
+            {
+                if (DateTime.UtcNow < lastGainTime + TamingCooldown)
+                {
+                    //owner.SendMessage("You must wait before gaining more taming experience."); // debug line
+                    return; // Player is still on cooldown, exit without gaining skill
+                }
+            }
+
+            double tamingSkill = owner.Skills[SkillName.Taming].Base;
+            double gainChance = 0.0;
+            double minGain = 0.0, maxGain = 0.0;
+
+            // Determine gain chance and amount based on skill level
+            if (tamingSkill <= 30.0) { gainChance = 0.20; minGain = 0.1; maxGain = 0.3; }
+            else if (tamingSkill <= 50.0) { gainChance = 0.15; minGain = 0.1; maxGain = 0.2; }
+            else if (tamingSkill <= 70.0) { gainChance = 0.10; minGain = 0.1; maxGain = 0.1; }
+            else if (tamingSkill <= 100.0) { gainChance = 0.05; minGain = 0.1; maxGain = 0.1; }
+
+            // Attempt taming skill gain
+            if (Utility.RandomDouble() < gainChance)
+            {
+                double tamingGain = minGain + (Utility.RandomDouble() * (maxGain - minGain)); // Random within range
+                owner.Skills[SkillName.Taming].Base += tamingGain;
+
+                // Select a random taming message
+                string message = TamingMessages[Utility.Random(TamingMessages.Length)];
+
+                // Display message over the pet's head
+                pet.PublicOverheadMessage(MessageType.Regular, pet.SpeechHue, false, 
+                    String.Format("{0} (+{1:F1} Taming)", String.Format(message, owner.Name), tamingGain));
+
+                // Set cooldown time for this player
+                _tamingCooldowns[owner] = DateTime.UtcNow;
+            }
+            else
+            {
+                // 10% chance to trigger a battle cry if no taming skill was gained
+                TryPetBattleCry(pet);
+            }
+        }
+
+        public static void TryPetBattleCry(BaseCreature pet)
+        {
+            if (pet == null || pet.ControlMaster == null)
+                return;
+
+            if (Utility.RandomDouble() < 0.10) // 10% chance if no skill gain
+            {
+                string battleCry = BattleCries[Utility.Random(BattleCries.Length)];
+
+                // Display battle cry over the pet's head
+                pet.PublicOverheadMessage(MessageType.Regular, pet.SpeechHue, false, 
+                    String.Format(battleCry, pet.ControlMaster.Name));
+            }
+        }
+    }
+}

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -1,3 +1,29 @@
+/*
+
+Created by Kopernicus
+
+KoperPets
+
+A pet system modification for the Secrets of Sosaria UO Shard.
+
+This script adds a small chance to gain taming skill when your pet fights, decreasing in amount and frequency as you increase in taming skill. Also included is a battle cry for your pets, they will occasionally remark on the battle.
+Installation
+
+WARNING: If you have modified your basecreature.cs script, do not replace it with this one. You will need to manually add the call for taming gain. Search my basecreature.cs script for KOPER.
+
+(This has been save file safe to add and remove for me, as it serializes no data. BUT, back up your save just for that warm fuzzy)
+
+    Be running current version of SoS
+
+    Place KoperPets folder in Data/Scripts/Custom
+
+    Backup your original Data/Scripts/Mobiles/Base/BaseCreature.cs
+
+    Place BaseCreature.cs from this repositiory in Data/Scripts/Mobiles/Base, replacing the original
+
+
+*/
+
 using System;
 using System.Collections.Generic;
 using Server;

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -1,29 +1,3 @@
-/*
-
-Created by Kopernicus
-
-KoperPets
-
-A pet system modification for the Secrets of Sosaria UO Shard.
-
-This script adds a small chance to gain taming skill when your pet fights, decreasing in amount and frequency as you increase in taming skill. Also included is a battle cry for your pets, they will occasionally remark on the battle.
-Installation
-
-WARNING: If you have modified your basecreature.cs script, do not replace it with this one. You will need to manually add the call for taming gain. Search my basecreature.cs script for KOPER.
-
-(This has been save file safe to add and remove for me, as it serializes no data. BUT, back up your save just for that warm fuzzy)
-
-    Be running current version of SoS
-
-    Place KoperPets folder in Data/Scripts/Custom
-
-    Backup your original Data/Scripts/Mobiles/Base/BaseCreature.cs
-
-    Place BaseCreature.cs from this repositiory in Data/Scripts/Mobiles/Base, replacing the original
-
-
-*/
-
 using System;
 using System.Collections.Generic;
 using Server;
@@ -38,63 +12,76 @@ namespace Server.Custom.KoperPets
         // Dictionary to track cooldowns (PlayerMobile -> Last Taming Gain Time)
         private static Dictionary<PlayerMobile, DateTime> _tamingCooldowns = new Dictionary<PlayerMobile, DateTime>();
 
-        private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(60); //  Set cooldown time (60 Seconds default)
+        private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); //  Set cooldown time (60 Seconds default)
 
         private static readonly string[] TamingMessages = new string[]
         {
-            "I feel closer to you, {0}!",
-            "We fight as one, {0}!",
-            "I trust you more, {0}.",
-            "Your guidance makes me stronger, {0}.",
-            "I will follow you anywhere, {0}.",
-            "I understand you better now, {0}!",
-            "You lead, I follow, {0}.",
-            "You are a worthy master, {0}!",
-            "Our bond grows, {0}!",
-            "Through battle, we become one, {0}.",
-            "I stand by your side, {0}.",
-            "I am learning from you, {0}.",
-            "You are my trusted master, {0}.",
-            "This battle strengthens our bond, {0}!",
-            "I heed your call, {0}.",
-            "I will fight for you always, {0}.",
-            "I am becoming stronger with you, {0}.",
-            "Together, we are unstoppable, {0}!"
+            "*{0} seems to trust their master more.*",
+            "*{0} appears more in sync with their master.*",
+            "*{0} moves with greater confidence alongside their master.*",
+            "*{0} looks to their master with newfound understanding.*",
+            "*{0} follows their master's guidance more closely.*",
+            "*{0} seems to grow stronger under their master's leadership.*",
+            "*{0} and their master fight in perfect harmony.*",
+            "*{0} moves with greater coordination beside their master.*",
+            "*{0} watches their master carefully, learning from every movement.*",
+            "*{0} responds to commands with increased precision.*",
+            "*{0} fights as though truly bonded with their master.*",
+            "*{0} appears more devoted to their master's cause.*",
+            "*{0} follows their master with unwavering loyalty.*",
+            "*{0} carries themselves with a newfound sense of purpose.*",
+            "*{0} seems more confident with their master by their side.*",
+            "*{0} appears more attuned to their master's presence.*",
+            "*{0} trusts their master more deeply after the battle.*",
+            "*{0} has grown more in tune with their master's instincts.*",
+            "*{0} learns from their master's movements, adapting quickly.*",
+            "*{0} fights with the precision of a well-trained companion.*",
+            "*{0} and their master move as one in battle.*",
+            "*{0} seems to have strengthened their bond through combat.*",
+            "*{0} watches their master with admiration and understanding.*",
+            "*{0} seems to feel a stronger connection with their master.*",
+            "*{0} reacts instantly to their master's unspoken commands.*",
+            "*{0} stands by their master with newfound resolve.*",
+            "*{0} seems more attuned to their master's emotions and intent.*",
+            "*{0} moves with perfect synchronization beside their master.*",
+            "*{0} fights with the dedication of a truly loyal companion.*",
+            "*{0} carries themselves like a seasoned warrior beside their master.*"
         };
 
         private static readonly string[] BattleCries = new string[]
         {
-            "For my master!",
-            "You will not harm {0}!",
-            "I will defend you, {0}, with my life!",
-            "Back away from {0}, or suffer my wrath!",
-            "I shall tear you apart!",
-            "You dare threaten my master?!",
-            "Face my fury!",
-            "I'll rip you to shreds!",
-            "Mess with {0}, and you answer to me!",
-            "Prepare to meet your end!",
-            "I fight for you, {0}!",
-            "Together, we are unstoppable!",
-            "I will never abandon you, {0}!",
-            "By your side, always!",
-            "For honor and for {0}!",
-            "With you, I fear nothing!",
-            "We've trained for this moment!",
-            "You lead, and I shall follow!",
-            "Nothing shall break our bond!",
-            "We fight as one!",
-            "You picked the wrong fight!",
-            "I'll make you regret that!",
-            "You're no match for me!",
-            "Let's see what you're made of!",
-            "I'll bite harder than you can handle!",
-            "I eat weaklings like you for breakfast!",
-            "You will fall before me!",
-            "I'll crush your bones!",
-            "Tremble before my might!",
-            "You will learn to fear me!"
+            "*{0} fights with everything they have!*",
+            "*{0} defends their master with unshakable loyalty!*",
+            "*{0} lunges at the enemy with full force!*",
+            "*{0} refuses to back down!*",
+            "*{0} charges fearlessly into battle!*",
+            "*{0} fights tooth and claw to protect their master!*",
+            "*{0} moves with incredible speed and precision!*",
+            "*{0} strikes fiercely, showing no mercy!*",
+            "*{0} launches a devastating attack!*",
+            "*{0} fights like a true warrior of the wild!*",
+            "*{0} stands their ground, refusing to falter!*",
+            "*{0} thrashes about with raw fury!*",
+            "*{0} roars in defiance as they attack!*",
+            "*{0} pushes themselves to the limit!*",
+            "*{0} is a blur of movement, overwhelming their foe!*",
+            "*{0} unleashes a powerful assault!*",
+            "*{0} gives it their all, undeterred by danger!*",
+            "*{0} fights with the might of a beast unchained!*",
+            "*{0} is relentless, never giving an inch!*",
+            "*{0} fights with unwavering determination!*",
+            "*{0} refuses to let their master come to harm!*",
+            "*{0} battles fiercely, driven by instinct!*",
+            "*{0} moves like a storm, striking again and again!*",
+            "*{0} delivers a crushing blow!*",
+            "*{0} does not hesitate, striking with full force!*",
+            "*{0} tears into their foe with savage intent!*",
+            "*{0} battles like a beast possessed!*",
+            "*{0} is relentless in their pursuit of victory!*",
+            "*{0} meets their foe head-on without fear!*",
+            "*{0} fights as if their very survival depends on it!*"
         };
+
 
         public static void TryTamingGain(BaseCreature pet, Mobile target)
         {
@@ -119,12 +106,16 @@ namespace Server.Custom.KoperPets
             double tamingSkill = owner.Skills[SkillName.Taming].Base;
             double gainChance = 0.0;
             double minGain = 0.0, maxGain = 0.0;
+            double tamingMultiplier = MyServerSettings.KoperTamingChance();  // Determine gain chance and amount based on skill level
+            //double tamingMultiplier = Server.Custom.KoperPets.KoperSkillConfig.TamingChanceMultiplier;  // Determine gain chance and amount based on skill level
 
             // Determine gain chance and amount based on skill level
-            if (tamingSkill <= 30.0) { gainChance = 0.20; minGain = 0.1; maxGain = 0.3; }
-            else if (tamingSkill <= 50.0) { gainChance = 0.15; minGain = 0.1; maxGain = 0.2; }
-            else if (tamingSkill <= 70.0) { gainChance = 0.10; minGain = 0.1; maxGain = 0.1; }
-            else if (tamingSkill <= 100.0) { gainChance = 0.05; minGain = 0.1; maxGain = 0.1; }
+            if (tamingMultiplier <= 0) tamingMultiplier = 1.0; // Ensure valid value
+            if (tamingSkill <= 30.0) { gainChance = 0.20 * tamingMultiplier; minGain = 0.1; maxGain = 0.3; }
+            else if (tamingSkill <= 50.0) { gainChance = 0.15 * tamingMultiplier; minGain = 0.1; maxGain = 0.2; }
+            else if (tamingSkill <= 70.0) { gainChance = 0.10 * tamingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            else if (tamingSkill < 100.0) { gainChance = 0.05 * tamingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            else return; // No gain if above 100
 
             // Attempt taming skill gain
             if (Utility.RandomDouble() < gainChance)
@@ -135,9 +126,8 @@ namespace Server.Custom.KoperPets
                 // Select a random taming message
                 string message = TamingMessages[Utility.Random(TamingMessages.Length)];
 
-                // Display message over the pet's head
-                pet.PublicOverheadMessage(MessageType.Regular, pet.SpeechHue, false, 
-                    String.Format("{0} (+{1:F1} Taming)", String.Format(message, owner.Name), tamingGain));
+                // Display message in system log
+                owner.SendMessage(0x83A, message);
 
                 // Set cooldown time for this player
                 _tamingCooldowns[owner] = DateTime.UtcNow;
@@ -156,11 +146,10 @@ namespace Server.Custom.KoperPets
 
             if (Utility.RandomDouble() < 0.10) // 10% chance if no skill gain
             {
-                string battleCry = BattleCries[Utility.Random(BattleCries.Length)];
+                string battleCry = String.Format(BattleCries[Utility.Random(BattleCries.Length)], pet.Name);
 
-                // Display battle cry over the pet's head
-                pet.PublicOverheadMessage(MessageType.Regular, pet.SpeechHue, false, 
-                    String.Format(battleCry, pet.ControlMaster.Name));
+                // Display battle cry in grey text
+                pet.PublicOverheadMessage(MessageType.Emote, 0x83A, false, battleCry);
             }
         }
     }

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -85,7 +85,7 @@ namespace Server.Custom.KoperPets
 
         public static void TryTamingGain(BaseCreature pet, Mobile target)
         {
-            if (pet == null || target == null)
+            if (pet == null || target == null || !MyServerSettings.KoperPets())
                 return;
 
             PlayerMobile owner = pet.ControlMaster as PlayerMobile;
@@ -144,7 +144,7 @@ namespace Server.Custom.KoperPets
             if (pet == null || pet.ControlMaster == null)
                 return;
 
-            if (Utility.RandomDouble() < 0.10) // 10% chance if no skill gain
+            if (Utility.RandomDouble() < 0.10 && MyServerSettings.KoperPetsImmersive()) // 10% chance if no skill gain
             {
                 string battleCry = String.Format(BattleCries[Utility.Random(BattleCries.Length)], pet.Name);
 

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -12,7 +12,7 @@ namespace Server.Custom.KoperPets
         // Dictionary to track cooldowns (PlayerMobile -> Last Taming Gain Time)
         private static Dictionary<PlayerMobile, DateTime> _tamingCooldowns = new Dictionary<PlayerMobile, DateTime>();
 
-        private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); //  Set cooldown time (60 Seconds default)
+        private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); //  Set cooldown time (20 Seconds default)
 
         private static readonly string[] TamingMessages = new string[]
         {

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -124,7 +124,7 @@ namespace Server.Custom.KoperPets
                 owner.Skills[SkillName.Taming].Base += tamingGain;
 
                 // Select a random taming message
-                string message = TamingMessages[Utility.Random(TamingMessages.Length)];
+                string message = string.Format(TamingMessages[Utility.Random(TamingMessages.Length)], pet.Name);
 
                 // Display message in system log
                 owner.SendMessage(0x83A, message);

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -111,9 +111,9 @@ namespace Server.Custom.KoperPets
 
             // Determine gain chance and amount based on skill level
             if (tamingMultiplier <= 0) tamingMultiplier = 1.0; // Ensure valid value
-            if (tamingSkill <= 30.0) { gainChance = 0.20 * tamingMultiplier; minGain = 0.1; maxGain = 0.3; }
-            else if (tamingSkill <= 50.0) { gainChance = 0.15 * tamingMultiplier; minGain = 0.1; maxGain = 0.2; }
-            else if (tamingSkill <= 70.0) { gainChance = 0.10 * tamingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            if (tamingSkill <= 30.0) { gainChance = 0.20 * tamingMultiplier; minGain = 0.1; maxGain = 1.0; }
+            else if (tamingSkill <= 50.0) { gainChance = 0.15 * tamingMultiplier; minGain = 0.1; maxGain = 0.5; }
+            else if (tamingSkill <= 70.0) { gainChance = 0.10 * tamingMultiplier; minGain = 0.1; maxGain = 0.2; }
             else if (tamingSkill < 100.0) { gainChance = 0.05 * tamingMultiplier; minGain = 0.1; maxGain = 0.1; }
             else return; // No gain if above 100
 

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -3993,6 +3993,16 @@ namespace Server.Mobiles
 				Timer.DelayCall( TimeSpan.FromSeconds( 10 ), new TimerCallback( ((PlayerMobile) from).RecoverAmmo ) );
 
 			base.OnDamage( amount, from, willKill );
+
+			// KOPERPETS CHANGE: Trigger skill gain
+    		PlayerMobile owner = this.ControlMaster as PlayerMobile;
+			
+    		if (this.Controlled && owner != null)
+    		{
+        		// Call the skill gain system, passing the pet (this) and the attacker
+        		Server.Custom.KoperPets.PetTamingSkillGain.TryTamingGain(this, from);
+    		}
+
 		}
 
 		public virtual void OnDamagedBySpell( Mobile from )

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -3993,7 +3993,8 @@ namespace Server.Mobiles
 				Timer.DelayCall( TimeSpan.FromSeconds( 10 ), new TimerCallback( ((PlayerMobile) from).RecoverAmmo ) );
 
 			base.OnDamage( amount, from, willKill );
-
+			
+			#region KoperPets
 			// KOPERPETS CHANGE: Trigger skill gain
     		PlayerMobile owner = this.ControlMaster as PlayerMobile;
 			
@@ -4002,6 +4003,7 @@ namespace Server.Mobiles
         		// Call the skill gain system, passing the pet (this) and the attacker
         		Server.Custom.KoperPets.PetTamingSkillGain.TryTamingGain(this, from);
     		}
+			#endregion
 
 		}
 
@@ -6080,6 +6082,17 @@ namespace Server.Mobiles
 
 				if ( m_ControlMaster != null )
 					m_ControlMaster.InvalidateProperties();
+
+				#region KoperPets
+				//KOPERPETS If the AI state is changed to a valid pet command, try to gain Herding skill
+        		if (ControlMaster != null && Controlled)
+        		{
+            		if (value == OrderType.Come || value == OrderType.Guard || value == OrderType.Follow || value == OrderType.Stay)
+            		{
+                		Server.Custom.KoperPets.KoperHerdingGain.TryGainHerdingSkill(ControlMaster);
+            		}
+        		}
+				#endregion
 			}
 		}
 

--- a/Data/Scripts/System/Misc/Settings.cs
+++ b/Data/Scripts/System/Misc/Settings.cs
@@ -586,7 +586,7 @@ namespace Server
 
 		public static double KoperHerdingChance()
 		{
-			return Math.Max(1.0, Math.Min(MySettings.S_KoperTamingChance, 10.0));
+			return Math.Max(1.0, Math.Min(MySettings.S_KoperHerdingChance, 10.0));
 		}
 
 		public static int KoperCooldown()

--- a/Data/Scripts/System/Misc/Settings.cs
+++ b/Data/Scripts/System/Misc/Settings.cs
@@ -568,6 +568,34 @@ namespace Server
 			return text;
 		}
 
+		#region KoperPets
+		public static bool KoperPets()
+		{
+			return MySettings.S_KoperPets;
+		}
+
+		public static bool KoperPetsImmersive()
+		{
+			return MySettings.S_KoperPetsImmersive;
+		}
+
+		public static double KoperTamingChance()
+		{
+			return Math.Max(1.0, Math.Min(MySettings.S_KoperTamingChance, 10.0));
+		}
+
+		public static double KoperHerdingChance()
+		{
+			return Math.Max(1.0, Math.Min(MySettings.S_KoperTamingChance, 10.0));
+		}
+
+		public static int KoperCooldown()
+		{
+			return Math.Max(0, Math.Min(MySettings.S_KoperCooldown, 600));
+		}
+		#endregion
+
+
 		public static int StartingGold()
 		{
 			int min = MySettings.S_MinGold;

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -722,7 +722,7 @@ namespace Server
 		// The KoperCooldown sets the minimum amount of time in seconds between taming/herding skill gain
 		// from fighting for taming, and commanding pets for herding. Minimum is 0, max is 600
 
-		public static int S_KoperCooldown = 60;
+		public static int S_KoperCooldown = 20;
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -703,7 +703,26 @@ namespace Server
 
 		public static int S_BondDays = 7;
 
+	// These settings affect the skill gain system for herding and taming. If the system bool is set 
+	// to true, the system will be active. If immersive messages is set to true, the game will display 
+	// immeersive skill gain messages. 
+		public static bool S_KoperPets = true;
 
+		public static bool S_KoperPetsImmersive = true;
+	
+	// The skill gain chance multiplier adjusts how likely you 
+	// are to gain skill from your pets fighting and obeying commands. The default is 1, where 1 gives 
+	// players a 20% chance to gain skill at <= 30 skill, 15% at <+50, 10% <= 70, and 5% after that.
+	// Maximum value is 10, min is 1.
+
+		public static double S_KoperTamingChance = 1.0;
+
+		public static double S_KoperHerdingChance = 1.0;
+
+		// The KoperCooldown sets the minimum amount of time in seconds between taming/herding skill gain
+		// from fighting for taming, and commanding pets for herding. Minimum is 0, max is 600
+
+		public static int S_KoperCooldown = 60;
 
 
 	///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This addition adds a small chance for skill gains when using a tamed pet in a fight:

            if (tamingSkill <= 30.0) { gainChance = 0.20; minGain = 0.1; maxGain = 0.3; }
            else if (tamingSkill <= 50.0) { gainChance = 0.15; minGain = 0.1; maxGain = 0.2; }
            else if (tamingSkill <= 70.0) { gainChance = 0.10; minGain = 0.1; maxGain = 0.1; }
            else if (tamingSkill <= 100.0) { gainChance = 0.05; minGain = 0.1; maxGain = 0.1; }

This adds a natural way for players to progress their taming abilities without spending hours taming/releasing/taming, or taming small animals over and over. The skill gain is on an adjustable cooldown, currently set to once per minute to prevent rapid skill gain. This can also be adjusted easily to further balance.

It also includes some player notication, and some fun battlecries from the pets while they are fighting, only occurring if a skill gain did not happen, and even then only with a 10% chance to prevent oversaturation of messages. These messages are displayed over the tamed pets heads.

I am also currently adapting the old, popular Jako's pet leveling/breeding system for this codebase, and will discuss on discord if that is desired. I have it 75% working at this point, and I think it would make a great addition to the codebase. 

Similat to other pull requests, feel free to use on your personal/server shards even if not implemented on the official branch!