### PR TITLE
Add setting to allow tweaking skill/stat loss at death

### DIFF
--- a/Data/Scripts/System/Misc/Death.cs
+++ b/Data/Scripts/System/Misc/Death.cs
@@ -35,7 +35,7 @@ namespace Server.Gumps
 
 			string sText = "";
 
-			string c1 = "5";
+			string c1 = MyServerSettings.DeathStatAndSkillLoss().ToString();
 			string c2 = "10";
 			string loss = "";
 
@@ -364,7 +364,7 @@ namespace Server.Gumps
 			string sText = "Do you wish to plead to the gods for your life back now? You may also continue on in your spirit form and seek out a shrine or healer.";
 			bool ResPenalty = false;
 
-			string c1 = "5";
+			string c1 = MyServerSettings.DeathStatAndSkillLoss().ToString();
 			string c2 = "10";
 			string loss = "";
 
@@ -475,7 +475,7 @@ namespace Server.Misc
 			if ( from is PlayerMobile && ( ( GetPlayerInfo.isFromSpace( from ) && !allPenalty ) || allPenalty ) )
 			{
 				double val1 = 0.10;
-				double val2 = 0.95;
+				double val2 = (100.0 - MyServerSettings.DeathStatAndSkillLoss()) / 100;
 
 				if ( GetPlayerInfo.isFromSpace( from ) && allPenalty )
 				{

--- a/Data/Scripts/System/Misc/Settings.cs
+++ b/Data/Scripts/System/Misc/Settings.cs
@@ -586,5 +586,10 @@ namespace Server
 
 			return gold;
 		}
+
+		public static double DeathStatAndSkillLoss()
+		{
+			return Math.Max(0.0, Math.Min(MySettings.S_DeathStatAndSkillLoss, 10.0));
+		}
 	}
 }

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -217,6 +217,10 @@ namespace Server
 		public static int S_DeathPayLevel = 5;
 		public static int S_DeathPayAmount = 20;
 
+	// Represents stat/skill loss (in percentage) when resurrecting without gold at a healer/ankh. Ranges from 0.0 to 10.0.
+
+		public static double S_DeathStatAndSkillLoss = 5.0;
+
 	// Spell damage toward monsters can be between 25 and 200 percent.
 
 		public static int S_SpellDamageIncreaseVsMonsters = 200;


### PR DESCRIPTION
This PR adds a new setting `S_DeathStatAndSkillLoss` to allow increasing, decreasing, or removing the stat and skill loss amount upon death when not resurrecting at a healer.

It ranges from 1% to 10% of current stats and skills, with a default of 5% (current value for _Secrets of Sosaria_).