### PR TITLE
Docs for stat/skill loss settings regarding aliens

### DIFF
--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -217,7 +217,8 @@ namespace Server
 		public static int S_DeathPayLevel = 5;
 		public static int S_DeathPayAmount = 20;
 
-	// Represents stat/skill loss (in percentage) when resurrecting without gold at a healer/ankh. Ranges from 0.0 to 10.0.
+	// Represents stat/skill loss (in percentage) when resurrecting without gold at a healer/ankh.
+	// This does not affect penalties for alien characters. Ranges from 0.0 to 10.0. The default is 5.0.
 
 		public static double S_DeathStatAndSkillLoss = 5.0;
 


### PR DESCRIPTION
Tiny tweak to docs for death stat and skill loss settings to indicate they have no effect on alien characters.