### PR TITLE
Add missing additional backpack harvest tool logic

### DIFF
--- a/Data/Scripts/Items/Trades/BaseHarvestTool.cs
+++ b/Data/Scripts/Items/Trades/BaseHarvestTool.cs
@@ -182,7 +182,9 @@ namespace Server.Items
 
 		public override void OnDoubleClick( Mobile from )
 		{
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack);
+
+			if ( Parent == from || canUseBackpackHarvestTool ) 
 			{
 				HarvestSystem.BeginHarvesting( from, this );
 			} 

--- a/Data/Scripts/Items/Trades/BaseTool.cs
+++ b/Data/Scripts/Items/Trades/BaseTool.cs
@@ -231,11 +231,11 @@ namespace Server.Items
 			}
 			else
 			{
-				if (MySettings.S_AllowBackpackCraftTool) {
-					from.SendLocalizedMessage( 1042004 ); // That must be equipped or in your pack to use it.
-				} else {
-					from.SendLocalizedMessage( 502641 ); // You must equip this item to use it.
-				}
+				int localizedMessageId = MySettings.S_AllowBackpackCraftTool
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 502641; // You must equip this item to use it.
+				
+				from.SendLocalizedMessage( localizedMessageId );
 			}
 		}
 

--- a/Data/Scripts/Items/Trades/BaseTool.cs
+++ b/Data/Scripts/Items/Trades/BaseTool.cs
@@ -206,11 +206,13 @@ namespace Server.Items
 
 		public override void OnDoubleClick( Mobile from )
 		{
+			bool canUseBackpackCraftTool = MySettings.S_AllowBackpackCraftTool && this.IsChildOf(from.Backpack);
+
 			if ( !MySettings.S_AllowMacroResources )
 			{ 
 				CaptchaGump.sendCaptcha(from, BaseTool.OnDoubleClickRedirected, this);
 			}
-			else if ( Parent == from || ( MySettings.S_AllowBackpackCraftTool && this.IsChildOf(from.Backpack) ) )
+			else if ( Parent == from || canUseBackpackCraftTool )
 			{
 				CraftSystem system = this.CraftSystem;
 
@@ -246,7 +248,9 @@ namespace Server.Items
 
 			BaseTool tool = (BaseTool)o;
 
-			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
+			bool canUseBackpackCraftTool = MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack);
+
+			if ( tool.Parent == from || canUseBackpackCraftTool )
 			{
 				CraftSystem system = tool.CraftSystem;
 
@@ -269,7 +273,7 @@ namespace Server.Items
 					? 1042004 // That must be equipped or in your pack to use it.
 					: 502641; // You must equip this item to use it.
 				
-				from.SendLocalizedMessage( localizedMessageId ); 
+				from.SendLocalizedMessage( localizedMessageId );
 			}
 		}
 

--- a/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
+++ b/Data/Scripts/Items/Weapons/Axes/BaseAxe.cs
@@ -97,7 +97,9 @@ namespace Server.Items
 			if ( HarvestSystem == null || Deleted )
 				return;
 
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack);
+
+			if ( Parent == from || canUseBackpackHarvestTool ) 
 			{
 				HarvestSystem.BeginHarvesting( from, this );
 			} 

--- a/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
+++ b/Data/Scripts/Items/Weapons/PoleArms/BasePoleArm.cs
@@ -65,7 +65,9 @@ namespace Server.Items
 			if ( HarvestSystem == null )
 				return;
 
-			if ( Parent == from || ( MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack) ) ) 
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool && this.IsChildOf(from.Backpack);
+
+			if ( Parent == from || canUseBackpackHarvestTool ) 
 			{
 				HarvestSystem.BeginHarvesting( from, this );
 			} 

--- a/Data/Scripts/Trades/Core/CraftGump.cs
+++ b/Data/Scripts/Trades/Core/CraftGump.cs
@@ -48,7 +48,9 @@ namespace Server.Engines.Craft
 			from.CloseGump( typeof( CraftGump ) );
 			from.CloseGump( typeof( CraftGumpItem ) );
 
-			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
+			bool canUseBackpackCraftTool = MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack);
+
+			if ( tool.Parent == from || canUseBackpackCraftTool )
 			{
 				AddPage( 0 );
 

--- a/Data/Scripts/Trades/Core/CraftGumpItem.cs
+++ b/Data/Scripts/Trades/Core/CraftGumpItem.cs
@@ -36,7 +36,10 @@ namespace Server.Engines.Craft
 
 			from.CloseGump( typeof( CraftGump ) );
 			from.CloseGump( typeof( CraftGumpItem ) );
-			if ( tool.Parent == from || ( MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack) ) )
+
+			bool canUseBackpackCraftTool = MySettings.S_AllowBackpackCraftTool && tool.IsChildOf(from.Backpack);
+
+			if ( tool.Parent == from || canUseBackpackCraftTool )
 			{
 				AddPage( 0 );
 				AddImage(0, 0, craftSystem.GumpImage, Server.Misc.PlayerSettings.GetGumpHue( from ));

--- a/Data/Scripts/Trades/Harvest/Fishing.cs
+++ b/Data/Scripts/Trades/Harvest/Fishing.cs
@@ -1071,7 +1071,9 @@ namespace Server.Engines.Harvest
 
 		public override bool BeginHarvesting( Mobile from, Item tool )
 		{
-			if ( from.FindItemOnLayer( Layer.OneHanded ) == null || tool != from.FindItemOnLayer( Layer.OneHanded ) )
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool && tool.IsChildOf(from.Backpack);
+
+			if ( tool.Parent != from && !canUseBackpackHarvestTool )
 			{
 				from.SendMessage("You need to be holding your fishing pole to fish.");
 				return false;

--- a/Data/Scripts/Trades/Harvest/Lumberjacking.cs
+++ b/Data/Scripts/Trades/Harvest/Lumberjacking.cs
@@ -154,9 +154,16 @@ namespace Server.Engines.Harvest
 			if ( !base.CheckHarvest( from, tool, def, toHarvest ) )
 				return false;
 
-			if ( tool.Parent != from )
-			{
-				from.SendLocalizedMessage( 500487 ); // The axe must be equipped for any serious wood chopping.
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool && tool.IsChildOf(from.Backpack);
+
+			if ( tool.Parent != from && !canUseBackpackHarvestTool )
+			{	
+				int localizedMessageId = MySettings.S_AllowBackpackHarvestTool 
+					? 1042004 // That must be equipped or in your pack to use it.
+					: 500487; // The axe must be equipped for any serious wood chopping.
+				
+				from.SendLocalizedMessage( localizedMessageId );
+
 				return false;
 			}
 


### PR DESCRIPTION
This PR adds missing checks for some harvest tools that were not following the `S_AllowBackpackHarvestTool` setting when enabled.

The following harvest scripts required additional checks above base that wouldn't allow backpack tool usage:

* `Data\Scripts\Trades\Harvest\Lumberjacking.cs`
* `Data\Scripts\Trades\Harvest\Fishing.cs`

This PR also improves backpack tool error handling and conditional checks for consistency and better code readability.

Fixes #191.