### PR TITLE
Allow customized signs for pre-built classic homes when S_AllowCustomHomes is disabled

### DIFF
--- a/Data/Scripts/System/Gumps/HouseGumpAOS.cs
+++ b/Data/Scripts/System/Gumps/HouseGumpAOS.cs
@@ -445,6 +445,7 @@ namespace Server.Gumps
 						}
 						else
 						{
+							AddButtonLabeled( 10, 210, GetButtonID( 5, 3 ), 1060761, isOwner && house.Public ); // Change House Sign
 							AddButtonLabeled( 10, 120, GetButtonID( 5, 7 ), 1060764, isCoOwner ); // Rename House
 						}
 					}


### PR DESCRIPTION
This allows worlds with only pre-built classic houses to still change the house sign type.

![image](https://github.com/user-attachments/assets/2cdd7ab7-2028-46c1-8a3e-d2442cafb1ad)

Thanks to @Djeryv for helping debug and track this one down.

Fixes #192.