### PR TITLE
Using "dotnet build" now outputs to System dir

### DIFF
--- a/Data/System/Source/COMPILE-README.md
+++ b/Data/System/Source/COMPILE-README.md
@@ -16,8 +16,8 @@ C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc /optimize /unsafe /t:exe /ou
 Ensure [dotnet](https://formulae.brew.sh/formula/dotnet) is installed via [Homebrew](https://brew.sh/).
 
 * Launch `Terminal.app` via Spotlight
-* Navigate to the SoS repo's `Data\System\Source` directory
+* Navigate to the SoS repo's `Data\System` directory
 
 ```
-dotnet build
+dotnet build Source
 ```

--- a/Data/System/Source/Source.csproj
+++ b/Data/System/Source/Source.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputPath>../</OutputPath>
     <OutputType>Exe</OutputType>
     <AssemblyName>World</AssemblyName>
     <ApplicationIcon>icon.ico</ApplicationIcon>


### PR DESCRIPTION
This is now consistent with the same output dir as the `csc` build process.

These changes do not affect the original `csc` build process.