### PR TITLE
Allow navigation of craft gump during queue

### DIFF
--- a/Data/Scripts/Mobiles/Base/PlayerMobile.cs
+++ b/Data/Scripts/Mobiles/Base/PlayerMobile.cs
@@ -103,8 +103,8 @@ namespace Server.Mobiles
 		public void CraftMessage()
 		{
 			Craft_Snd_Timer = Timer.DelayCall( TimeSpan.FromSeconds( 1.0 ), new TimerStateCallback( CraftSound_Callback ), this );
-			Craft_Aft_Timer = Timer.DelayCall( TimeSpan.FromSeconds( 3.0 ), new TimerStateCallback( CraftAfter_Callback ), this );
-			Craft_Msg_Timer = Timer.DelayCall( TimeSpan.FromSeconds( 5.0 ), new TimerStateCallback( CraftMessage_Callback ), this );
+			Craft_Aft_Timer = Timer.DelayCall( TimeSpan.FromSeconds( 1.5 ), new TimerStateCallback( CraftAfter_Callback ), this );
+			Craft_Msg_Timer = Timer.DelayCall( TimeSpan.FromSeconds( 2.0 ), new TimerStateCallback( CraftMessage_Callback ), this );
 		}
 
 		private void CraftMessage_Callback( object state )

--- a/Data/Scripts/Trades/Core/CraftSystem.cs
+++ b/Data/Scripts/Trades/Core/CraftSystem.cs
@@ -187,7 +187,7 @@ namespace Server.Engines.Craft
 		{
 			if ( m is PlayerMobile )
 				if ( CraftSystem.CraftGetQueue( m ) > 1 )
-					((PlayerMobile)m).CraftDone = DateTime.Now + TimeSpan.FromSeconds( 7.0 );
+					((PlayerMobile)m).CraftDone = DateTime.Now + TimeSpan.FromSeconds( 2.0 );
 		}
 
 		public static bool CraftFinished( Mobile m, BaseTool tool )


### PR DESCRIPTION
Previously, the entire gump was rendered useless by blocking all actions (even closing it!) if there was a craft queue active.

Now, the gump can be navigated while waiting for the craft queue to complete.

The changes in this PR allow "non-volatile" buttons to remain responsive, such as viewing categories, picking a material, etc. Now you can actually close the gump instead of waiting for the queue to finish! Starting a new craft queue is still restricted while waiting for a craft queue to finish.

These changes only apply when S_CraftMany is set to true.

Fixes #201.