### PR TITLE
Server setting for pet control slots using either base or modified skill value

### DIFF
--- a/Data/Scripts/Mobiles/Base/PlayerMobile.cs
+++ b/Data/Scripts/Mobiles/Base/PlayerMobile.cs
@@ -805,17 +805,17 @@ namespace Server.Mobiles
 		}
 
 		public virtual void UpdateFollowers(){
-			this.FollowersMax = CalculateFollowersMax(MySettings.S_ItemInfluencedTamingSlots);
+			this.FollowersMax = CalculateFollowersMax();
 			// Additional slots, if configured, are added after the max is determined by skill mastery above
 			this.FollowersMax += MyServerSettings.AdditionalFollowerSlots();
 		}
 
-		private int CalculateFollowersMax(bool itemsInfluenceTamingSlots)
+		private int CalculateFollowersMax()
 		{
-			double herding = itemsInfluenceTamingSlots ? this.Skills[SkillName.Herding].Value : this.Skills[SkillName.Herding].Base;
-			double veterinary = itemsInfluenceTamingSlots ? this.Skills[SkillName.Veterinary].Value : this.Skills[SkillName.Veterinary].Base;
-			double druidism = itemsInfluenceTamingSlots ? this.Skills[SkillName.Druidism].Value : this.Skills[SkillName.Druidism].Base;
-			double taming = itemsInfluenceTamingSlots ? this.Skills[SkillName.Taming].Value : this.Skills[SkillName.Taming].Base;
+			double herding = MySettings.S_ItemInfluencedTamingSlots ? this.Skills[SkillName.Herding].Value : this.Skills[SkillName.Herding].Base;
+			double veterinary = MySettings.S_ItemInfluencedTamingSlots ? this.Skills[SkillName.Veterinary].Value : this.Skills[SkillName.Veterinary].Base;
+			double druidism = MySettings.S_ItemInfluencedTamingSlots ? this.Skills[SkillName.Druidism].Value : this.Skills[SkillName.Druidism].Base;
+			double taming = MySettings.S_ItemInfluencedTamingSlots ? this.Skills[SkillName.Taming].Value : this.Skills[SkillName.Taming].Base;
 
 			if (herding >= 120 && veterinary >= 120 && druidism >= 120 && taming >= 120)
 				return 8;

--- a/Data/Scripts/Mobiles/Base/PlayerMobile.cs
+++ b/Data/Scripts/Mobiles/Base/PlayerMobile.cs
@@ -805,21 +805,26 @@ namespace Server.Mobiles
 		}
 
 		public virtual void UpdateFollowers(){
-
-			if ( (this.Skills[SkillName.Herding].Base >= 120.0) && (this.Skills[SkillName.Veterinary].Base >= 120.0) && (this.Skills[SkillName.Druidism].Base >= 120.0) && (this.Skills[SkillName.Taming].Base >= 120.0) )
-			this.FollowersMax = 8;
-
-			else if ( (this.Skills[SkillName.Herding].Base >= 90) && (this.Skills[SkillName.Veterinary].Base >= 90) && (this.Skills[SkillName.Druidism].Base >= 90) && (this.Skills[SkillName.Taming].Base >= 90) )
-			this.FollowersMax = 7;
-
-			else if ( (this.Skills[SkillName.Herding].Base >= 60) && (this.Skills[SkillName.Veterinary].Base >= 60) && (this.Skills[SkillName.Druidism].Base >= 60) && (this.Skills[SkillName.Taming].Base >= 60) )
-			this.FollowersMax = 6;
-
-			else 
-			this.FollowersMax = 5;
-
+			this.FollowersMax = CalculateFollowersMax(MySettings.S_ItemInfluencedTamingSlots);
 			// Additional slots, if configured, are added after the max is determined by skill mastery above
 			this.FollowersMax += MyServerSettings.AdditionalFollowerSlots();
+		}
+
+		private int CalculateFollowersMax(bool itemsInfluenceTamingSlots)
+		{
+			double herding = itemsInfluenceTamingSlots ? this.Skills[SkillName.Herding].Value : this.Skills[SkillName.Herding].Base;
+			double veterinary = itemsInfluenceTamingSlots ? this.Skills[SkillName.Veterinary].Value : this.Skills[SkillName.Veterinary].Base;
+			double druidism = itemsInfluenceTamingSlots ? this.Skills[SkillName.Druidism].Value : this.Skills[SkillName.Druidism].Base;
+			double taming = itemsInfluenceTamingSlots ? this.Skills[SkillName.Taming].Value : this.Skills[SkillName.Taming].Base;
+
+			if (herding >= 120 && veterinary >= 120 && druidism >= 120 && taming >= 120)
+				return 8;
+			if (herding >= 90 && veterinary >= 90 && druidism >= 90 && taming >= 90)
+				return 7;
+			if (herding >= 60 && veterinary >= 60 && druidism >= 60 && taming >= 60)
+				return 6;
+
+			return 5;
 		}
 
 		public override int GetMaxResistance( ResistanceType type )

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -147,7 +147,7 @@ namespace Server
 
 	// If true, a player character cannot use macros to improve their skills quickly.
 
-		public static bool S_NoMacroing = false;
+		public static bool S_NoMacroing = true;
 
 	// You can increase the rate that stats gain from 50.0 (slow) to 10.0 (fast).
 
@@ -488,7 +488,7 @@ namespace Server
 	// value higher than 10 could mean that the paralyze cooldown is lower than its duration, 
 	// which can lead to frustrating fights as enemies can flee and chain-paralyze a character until they heal 
 	// enough to get back into the fight. 
-		public static double S_paralyzeDuration = 5.0;
+		public static double S_paralyzeDuration = 10.0;
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// 008 - MERCHANTS ////////////////////////////////////////////////////////////////////////////
@@ -502,11 +502,11 @@ namespace Server
 
 	// If true (default false) then vendors will sell anything they normally stock. Some items have a default rarity % that this setting does not affect.
 
-		public static bool S_SellAll = true;
+		public static bool S_SellAll = false;
 
 	// If true (default false) then vendors will buy anything they normally stock. Some items have a default rarity % that this setting does not affect.
 
-		public static bool S_BuyAll = true;
+		public static bool S_BuyAll = false;
 
 	// If false, then vendors will NOT buy some tailor materials (cotton, flax, wool, regular cloth, and string).
 	// Does not affect a custom merchant that is set to buy such items.
@@ -746,7 +746,7 @@ namespace Server
 	// extra follower slots. 
 
 		public static bool S_ItemInfluencedTamingSlots = true;
-	
+		
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// 011 - TOWNS & CITIES ///////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////////////////
@@ -787,7 +787,7 @@ namespace Server
 	// game. Any settings here, that interfere with your enjoyment of the game, are under your
 	// control and you can change these settings at any time if you wish to.
 
-		public static bool S_Reviewed = true;
+		public static bool S_Reviewed = false;
 
 
 	}

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -147,7 +147,7 @@ namespace Server
 
 	// If true, a player character cannot use macros to improve their skills quickly.
 
-		public static bool S_NoMacroing = true;
+		public static bool S_NoMacroing = false;
 
 	// You can increase the rate that stats gain from 50.0 (slow) to 10.0 (fast).
 
@@ -488,7 +488,7 @@ namespace Server
 	// value higher than 10 could mean that the paralyze cooldown is lower than its duration, 
 	// which can lead to frustrating fights as enemies can flee and chain-paralyze a character until they heal 
 	// enough to get back into the fight. 
-		public static double S_paralyzeDuration = 10.0;
+		public static double S_paralyzeDuration = 5.0;
 
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// 008 - MERCHANTS ////////////////////////////////////////////////////////////////////////////
@@ -502,11 +502,11 @@ namespace Server
 
 	// If true (default false) then vendors will sell anything they normally stock. Some items have a default rarity % that this setting does not affect.
 
-		public static bool S_SellAll = false;
+		public static bool S_SellAll = true;
 
 	// If true (default false) then vendors will buy anything they normally stock. Some items have a default rarity % that this setting does not affect.
 
-		public static bool S_BuyAll = false;
+		public static bool S_BuyAll = true;
 
 	// If false, then vendors will NOT buy some tailor materials (cotton, flax, wool, regular cloth, and string).
 	// Does not affect a custom merchant that is set to buy such items.
@@ -741,7 +741,12 @@ namespace Server
 
 		public static int S_KoperCooldown = 20;
 
+	// This setting control whether extra taming slots from skills are calculated based on modified skill base (which is the default) 
+	// or base skill value alone. The modified value accounts for item bonuses, while base value only uses actual skill to determine
+	// extra follower slots. 
 
+		public static bool S_ItemInfluencedTamingSlots = true;
+	
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// 011 - TOWNS & CITIES ///////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////////////////
@@ -782,7 +787,7 @@ namespace Server
 	// game. Any settings here, that interfere with your enjoyment of the game, are under your
 	// control and you can change these settings at any time if you wish to.
 
-		public static bool S_Reviewed = false;
+		public static bool S_Reviewed = true;
 
 
 	}


### PR DESCRIPTION
cleans up the code and adds a server setting to check whether skill base value or gear-modified value should be tested when calculating follower slots. 