### PR TITLE
fixes the skill check on koper taming systems

### DIFF
--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -8,7 +8,7 @@ namespace Server.Custom.KoperPets
     public static class KoperHerdingGain
     {
         private static readonly Dictionary<Mobile, DateTime> _cooldowns = new Dictionary<Mobile, DateTime>();
-        private static readonly TimeSpan CooldownTime = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); // 20-second cooldown
+        private static readonly TimeSpan CooldownTime = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); //  Set cooldown time (20 Seconds default)
 
         private static readonly string[] SuccessMessages = new string[]
         {
@@ -42,23 +42,21 @@ namespace Server.Custom.KoperPets
 
             double herdingSkill = owner.Skills[SkillName.Herding].Base;
             double gainChance;
-            double minGain;
-            double maxGain;
             double herdingMultiplier = MyServerSettings.KoperHerdingChance();
 
 
             // Determine gain chance and amount based on skill level
             if (herdingMultiplier <= 0) herdingMultiplier = 1.0; // Ensure valid value
-            if (herdingSkill <= 30.0) { gainChance = 0.20 * herdingMultiplier; minGain = 0.1; maxGain = 1.0; }
-            else if (herdingSkill <= 50.0) { gainChance = 0.15 * herdingMultiplier; minGain = 0.1; maxGain = 0.5; }
-            else if (herdingSkill <= 70.0) { gainChance = 0.10 * herdingMultiplier; minGain = 0.1; maxGain = 0.2; }
-            else if (herdingSkill < 100.0) { gainChance = 0.05 * herdingMultiplier; minGain = 0.1; maxGain = 0.1; }
+            if (herdingMultiplier >= 10) herdingMultiplier = 10.0; // Ensure valid value
+            if (herdingSkill <= 30.0) { gainChance = 0.20 * herdingMultiplier;}
+            else if (herdingSkill <= 50.0) { gainChance = 0.15 * herdingMultiplier;}
+            else if (herdingSkill <= 70.0) { gainChance = 0.10 * herdingMultiplier;}
+            else if (herdingSkill < 125.0) { gainChance = 0.05 * herdingMultiplier;}
             else return; // No gain if at max skill
 
             if (Utility.RandomDouble() <= gainChance)
             {
-                double skillGain = Utility.RandomDouble() * (maxGain - minGain) + minGain;
-                owner.Skills[SkillName.Herding].Base += skillGain;
+                owner.CheckSkill(SkillName.Herding, 0.0 , 125.0 );
 
                 // Select a random message for variety
                 if (MyServerSettings.KoperPetsImmersive()) 

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -9,7 +9,6 @@ namespace Server.Custom.KoperPets
 {
     public static class PetTamingSkillGain
     {
-        // Dictionary to track cooldowns (PlayerMobile -> Last Taming Gain Time)
         private static Dictionary<PlayerMobile, DateTime> _tamingCooldowns = new Dictionary<PlayerMobile, DateTime>();
 
         private static readonly TimeSpan TamingCooldown = TimeSpan.FromSeconds(MyServerSettings.KoperCooldown()); //  Set cooldown time (20 Seconds default)
@@ -105,24 +104,22 @@ namespace Server.Custom.KoperPets
 
             double tamingSkill = owner.Skills[SkillName.Taming].Base;
             double gainChance = 0.0;
-            double minGain = 0.0, maxGain = 0.0;
             double tamingMultiplier = MyServerSettings.KoperTamingChance();  // Determine gain chance and amount based on skill level
-            //double tamingMultiplier = Server.Custom.KoperPets.KoperSkillConfig.TamingChanceMultiplier;  // Determine gain chance and amount based on skill level
-
+          
             // Determine gain chance and amount based on skill level
             if (tamingMultiplier <= 0) tamingMultiplier = 1.0; // Ensure valid value
-            if (tamingSkill <= 30.0) { gainChance = 0.20 * tamingMultiplier; minGain = 0.1; maxGain = 1.0; }
-            else if (tamingSkill <= 50.0) { gainChance = 0.15 * tamingMultiplier; minGain = 0.1; maxGain = 0.5; }
-            else if (tamingSkill <= 70.0) { gainChance = 0.10 * tamingMultiplier; minGain = 0.1; maxGain = 0.2; }
-            else if (tamingSkill < 100.0) { gainChance = 0.05 * tamingMultiplier; minGain = 0.1; maxGain = 0.1; }
-            else return; // No gain if above 100
+            if (tamingMultiplier >= 10) tamingMultiplier = 10.0; // Ensure valid value
+            if (tamingSkill <= 30.0) { gainChance = 0.20 * tamingMultiplier;}
+            else if (tamingSkill <= 50.0) { gainChance = 0.15 * tamingMultiplier;}
+            else if (tamingSkill <= 70.0) { gainChance = 0.10 * tamingMultiplier;}
+            else if (tamingSkill < 125.0) { gainChance = 0.05 * tamingMultiplier;}
+            else return; // No gain if at max skill
 
             // Attempt taming skill gain
             if (Utility.RandomDouble() < gainChance)
             {
-                double tamingGain = minGain + (Utility.RandomDouble() * (maxGain - minGain)); // Random within range
-                owner.Skills[SkillName.Taming].Base += tamingGain;
-
+                owner.CheckSkill(SkillName.Taming, 0.0 , 125.0);
+            
                 // Select a random taming message
                 string message = string.Format(TamingMessages[Utility.Random(TamingMessages.Length)], pet.Name);
 

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -737,7 +737,7 @@ namespace Server
 		public static double S_KoperHerdingChance = 1.0;
 
 	// The KoperCooldown sets the minimum amount of time in seconds between taming/herding skill gain
-	// from fighting for taming, and commanding pets for herding. Minimum is 0, max is 600
+	// from fighting for taming, and commanding pets for herding. Minimum is 0, max is 600, default is 20.
 
 		public static int S_KoperCooldown = 20;
 


### PR DESCRIPTION
this change prevents unwanted skill gains in taming/herding if the koper pets system is enabled and converts the gains into a regular skill check. 