### PR TITLE
rebalances zombie lords for more engaging fights

### DIFF
--- a/Data/Scripts/Mobiles/Undead/RottingCorpse.cs
+++ b/Data/Scripts/Mobiles/Undead/RottingCorpse.cs
@@ -38,11 +38,11 @@ namespace Server.Mobiles
 			SetDex( 75 );
 			SetInt( 151, 200 );
 
-			SetHits( 1200 );
+			SetHits( 558, 611  );
 			SetStam( 150 );
 			SetMana( 0 );
 
-			SetDamage( 8, 10 );
+			SetDamage( 16, 20 );
 
 			SetDamageType( ResistanceType.Physical, 0 );
 			SetDamageType( ResistanceType.Cold, 50 );
@@ -55,7 +55,7 @@ namespace Server.Mobiles
 			SetResistance( ResistanceType.Energy, 20, 30 );
 
 			SetSkill( SkillName.Poisoning, 120.0 );
-			SetSkill( SkillName.MagicResist, 250.0 );
+			SetSkill( SkillName.MagicResist, 120.0 );
 			SetSkill( SkillName.Tactics, 100.0 );
 			SetSkill( SkillName.FistFighting, 90.1, 100.0 );
 


### PR DESCRIPTION
The way its set currently, ancient zombies have almost double the health of a primeval dragon, much higher magic resist and almost no way of dealing meaningful damage, which leads to extremely boring fights in which a player has to slowly chip away at a gigantic health pool while not much else happens. 

This change cuts high end zombies health in about half and greatly improves their base damage, so they are still something that has to be approached with care, but that won't make anyone fall asleep in front of their screen. 