### PR TITLE
Allow shovel use from backpack for treasure maps

### DIFF
--- a/Data/Scripts/Items/Trades/Cartography/Maps/TreasureMap.cs
+++ b/Data/Scripts/Items/Trades/Cartography/Maps/TreasureMap.cs
@@ -243,9 +243,17 @@ namespace Server.Items
 			if ( m.Backpack == null )
 				return false;
 
-			Item shovel = m.FindItemOnLayer( Layer.TwoHanded );
+			bool canUseBackpackHarvestTool = MySettings.S_AllowBackpackHarvestTool;
+			bool hasShovel = m.Backpack.FindItemByType( typeof( Spade ) ) != null;
 
-			if ( shovel is Spade )
+			if ( canUseBackpackHarvestTool && hasShovel )
+				return true;
+
+			Item shovel = m.FindItemOnLayer( Layer.TwoHanded );
+			
+			bool isHoldingShovel = (shovel != null && shovel is Spade);
+
+			if ( isHoldingShovel )
 				return true;
 
 			return false;

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -404,7 +404,8 @@ namespace Server
 		public static bool S_AllowBackpackCraftTool = false;
 
 	// If false, then characters will need to have the appropriate tool equipped to gather resources.
-		
+	// Affects harvest tools that serve additional purposes (such as grave digging or hunting treasure).
+
 		public static bool S_AllowBackpackHarvestTool = false;
 
 


### PR DESCRIPTION
Adds a check for treasure maps to allow using a shovel to dig for chests without equipping it if `S_AllowBackpackHarvestTool` is enabled.

Fixes #256.