### PR TITLE
adds a small chance that an adventurer in the wilds will have a rare item on their bag

### DIFF
--- a/Data/Scripts/Items/Containers/Loot.cs
+++ b/Data/Scripts/Items/Containers/Loot.cs
@@ -700,6 +700,28 @@ namespace Server
 		public static Type[] RareItemTypes{ get{ return m_RareItemTypes; } }
 
 		// ------------------------------------------------------------------------------------------------------------------------------------------
+		private static Type[] m_AdventurerRareItemTypes = new Type[]
+			{
+				typeof( SkeletonsKey ),			typeof( MagicalDyes ),					typeof( EtherealPowerScroll),
+				typeof( HeavySharpeningStone ),	typeof( ConsecratedSharpeningStone ),	typeof( SummonPrison ),
+				typeof( MagicPigment ),			typeof( RunicHammer ),					typeof( RunicSaw ),
+				typeof( RoughSharpeningStone ),	typeof( DenseSharpeningStone ),			typeof( ElementalSharpeningStone ),
+				typeof( ArtifactManual ),		typeof( Runebook ),						typeof( FrankenJournalInBox ),
+				typeof( CrystallineJar ),		typeof( DockingLantern ),				typeof( RunicFletching ),
+				typeof( BoatBuild ),			typeof( MalletStake ), 					typeof( PetBondDeed ),
+				typeof( HairDyeBottle ),		typeof( MagicalWand ),					typeof( MagicalWand ),
+				typeof( RareAnvil ),			typeof( MasterSkeletonsKey ),			typeof( InvulnerabilityPotion ),
+				typeof( AlternateRealityMap ),	typeof( UnusualDyes ),					typeof( RunicLeatherKit ),
+				typeof( CarpetBuild ),			typeof( RunicScales ),					typeof( GolemManual ),
+				typeof( SmallHollowBook ),		typeof( LargeHollowBook ),				typeof( RecallRune),
+				typeof( SlaversNet ),			typeof( TelescopeAddonDeed ),			typeof( RunicUndertaker ),
+				typeof( RunicTinker ),			typeof( RunicSewingKit )				
+			};
+
+		public static Type[] AdventurerRareItemTypes{ get{ return m_RareItemTypes; } }
+		// ------------------------------------------------------------------------------------------------------------------------------------------
+
+		// ------------------------------------------------------------------------------------------------------------------------------------------
 
 		private static Type[] m_CraftsTypes = new Type[]
 			{

--- a/Data/Scripts/Mobiles/Humanoids/Humans/Adventurers.cs
+++ b/Data/Scripts/Mobiles/Humanoids/Humans/Adventurers.cs
@@ -128,6 +128,15 @@ namespace Server.Mobiles
 			if ( CitizenLevel > 4 ){ AddLoot( LootPack.Rich ); }
 			if ( CitizenLevel > 2 ){ AddLoot( LootPack.Average ); }
 			AddLoot( LootPack.Meager );
+			// adventurers have a 1 in 25 chance of having one rare item in their pack 
+			if (Utility.Random(25) == 0)
+    		{
+    		    Type rareType = Loot.AdventurerRareItemTypes[Utility.Random(Loot.AdventurerRareItemTypes.Length)];
+    		    Item rare = Activator.CreateInstance(rareType) as Item;
+    		    if (rare != null)
+    		        PackItem(rare);
+    		}
+
 
 			if ( CitizenType == 1 ){ AddLoot( LootPack.MedScrolls, ( (int)( ( CitizenLevel / 3 ) + 1 ) ) ); }
 		}


### PR DESCRIPTION
Purples serve little purpose in the game aside from terrorizing newbie monster players and sometimes getting accidentaly flagged with AoE spells. 

This change adds interest to them by adding a couple interesting/rare items on them occasionally, so thieves can look forward to stealing from them, and reds can murder them for a chance of something shiny. 

The chances are 1/25, and if it connects, one of the following items will be added to the mobile's bag:

![image](https://github.com/user-attachments/assets/cdc41321-255e-48da-bc54-246da5aa2c47)
