### PR TITLE
when selling more than 20k worth of gold at once, the player receives a bank check instead of gold

### DIFF
--- a/Data/Scripts/Mobiles/Base/BaseVendor.cs
+++ b/Data/Scripts/Mobiles/Base/BaseVendor.cs
@@ -2028,14 +2028,15 @@ namespace Server.Mobiles
 				this.CoinPurse -= GiveGold;
 
 				this.InvalidateProperties();
-
-				while ( GiveGold > 60000 )
+				
+				if(GiveGold > 20000)
 				{
-					seller.AddToBackpack( new Gold( 60000 ) );
-					GiveGold -= 60000;
+					seller.AddToBackpack( new BankCheck( GiveGold ) );
+				} 
+				else
+				{
+					seller.AddToBackpack( new Gold( GiveGold ) );
 				}
-
-				seller.AddToBackpack( new Gold( GiveGold ) );
 
 				seller.PlaySound( 0x0037 );//Gold dropping sound
 


### PR DESCRIPTION
This was added to prevent players from getting too much gold at once. A bank check will be given to the player instead of large sums of money. 

Implements #278 