### PR TITLE
greatly reduces the base dispel chance for summoned creatures. 

### DIFF
--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -6348,7 +6348,7 @@ namespace Server.Mobiles
 
 		public bool DispelChecks( Mobile m )
 		{
-			double DispelChance = 0.75; // 75% chance to dispel at gm magery
+			double DispelChance = 0.33; // 33% chance to dispel at gm magery
 
 			bool willDispel = true;
 			int nope = MySettings.S_DispelFailure;


### PR DESCRIPTION
Currently, enemies hit way too fast for a 75% base dispel chance to be taken seriously. This change makes it so that summoner-type characters have more of a fighting chance. More changes will be added in the future related to this playstile, but this is a good first step to give them more power and less busywork during gameplay. 