### PR TITLE
randomizes the level of trapdoors and slightly reduces base gold income from them

### DIFF
--- a/Data/Scripts/Items/Containers/HiddenChest.cs
+++ b/Data/Scripts/Items/Containers/HiddenChest.cs
@@ -60,7 +60,7 @@ namespace Server.Items
 					Map map = m.Map;
 					string where = Server.Misc.Worlds.GetRegionName( m.Map, m.Location );
 
-					int money = Utility.RandomMinMax( 100, 200 );
+					int money = Utility.RandomMinMax( 50, 150 );
 
 					switch( Utility.RandomMinMax( 1, level ) )
 					{

--- a/Data/Scripts/System/Skills/Searching.cs
+++ b/Data/Scripts/System/Skills/Searching.cs
@@ -214,7 +214,10 @@ namespace Server.SkillHandlers
 				}
 				else if ( item is HiddenChest )
 				{
-					int level = (int)(m.Skills[SkillName.Searching].Value / 10);
+					int minLevel = (int)(m.Skills[SkillName.Searching].Value / 25 );
+					int maxLevel = (int)(m.Skills[SkillName.Searching].Value / 10 );
+					// at 100 searching, generates a box between level 4 and 10
+					int level = Utility.RandomMinMax(minLevel,maxLevel);
 						if (level < 1){level = 1;}
 						if (level > 10){level = 10;}
 


### PR DESCRIPTION
Searching is an effortless skill to raise, and offers larger returns than any other skill that offers similar investment. 
That happened mainly because the character would always get extremely high level lootboxes at max skill, which generated large piles of coins and other items. 
This change makes the base value of generated coins slightly smaller, and makes the level 10 boxes much rarer, so boxes will still be a profitable way to earn loot, but not the main gameplay form of every single newbie out there. 

Searching still offers other utility in trap protection and door detection. I think that it was doing too much in exchange for too little and that it shortened the amount of time that an adventurer had to spend before buying a home by the sea by a large amount. 