### PR TITLE
added veterinarian supplies to the game

### DIFF
--- a/Data/Scripts/Items/Trades/Misc/Bandage.cs
+++ b/Data/Scripts/Items/Trades/Misc/Bandage.cs
@@ -564,6 +564,10 @@ namespace Server.Items
 			{
 				healer.SendLocalizedMessage( 501042 ); // Target cannot be resurrected at that location.
 			}
+			else if (HealingCooldownTracker.IsOnVetSupplyCooldown(healer))
+			{
+				healer.SendMessage("You cannot use bandages while veterinary supplies are in use.");
+			}
 			else if ( healer.CanBeBeneficial( patient, true, true ) )
 			{
 				healer.DoBeneficial( patient );
@@ -583,9 +587,8 @@ namespace Server.Items
 				healer.SendMessage ( "" + String.Format(" {0:0.0}s", new DateTime(TimeSpan.FromMilliseconds( HealTimer( healer, patient ) ).Ticks).ToString("s.ff") ) + "" );
 				healer.SendLocalizedMessage( 500956 ); // You begin applying the bandages.
 				healer.LocalOverheadMessage( MessageType.Regular, 1150, 500956 );
-
 				BuffInfo.AddBuff( healer, new BuffInfo( BuffIcon.Bandage, 1063670, TimeSpan.FromMilliseconds( HealTimer( healer, patient ) ), healer ) );
-
+				HealingCooldownTracker.SetBandageCooldown(healer, TimeSpan.FromMilliseconds( HealTimer( healer, patient ) ));
 				return context;
 			}
 

--- a/Data/Scripts/Items/Trades/Misc/VeterinarySupplies.cs
+++ b/Data/Scripts/Items/Trades/Misc/VeterinarySupplies.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+using Server.Items;
+using Server.Targeting;
+using Server.Network;
+
+namespace Server.Items
+{
+    public class VeterinarySupplies : Item
+    {
+        public override int LabelNumber { get { return 1152729; } }
+        public override double DefaultWeight { get { return 5.0; } }
+        private static readonly TimeSpan MaxCooldown = TimeSpan.FromSeconds(9.0);
+        private static readonly TimeSpan MinCooldown = TimeSpan.FromSeconds(4.5);
+
+        public override string DefaultDescription{ get{ return "Veterinary supplies require a both Veterinary and Druidism skills. When you use them on someone, it will begin the attempt to heal some damage on all of your followers. If your skills are high enough, you can cure most poisons or even bring the dead back to life."; } }
+        private static Dictionary<Mobile, DateTime> m_LastUse = new Dictionary<Mobile, DateTime>();
+        
+        private int m_UsesRemaining = 200;
+
+        [CommandProperty(AccessLevel.Player)]
+        public int UsesRemaining
+        {
+            get { return m_UsesRemaining; }
+            set { m_UsesRemaining = value; InvalidateProperties(); }
+        }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+            list.Add("Veterinary Supplies");
+            list.Add("Uses Remaining: " + m_UsesRemaining.ToString());
+        }
+
+        [Constructable]
+        public VeterinarySupplies() : base(0xE21)
+        {
+            Name = "Veterinary Supplies";
+            ItemID = 0x1E21;
+            Hue = 0x3A;
+        }
+
+        public VeterinarySupplies(Serial serial) : base(serial) { }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!IsChildOf(from.Backpack))
+            {
+                from.SendMessage("You must have the Veterinary Supplies in your backpack to use them.");
+                return;
+            }
+
+            if (from.Followers == 0)
+            {
+                from.SendMessage("You have no followers to tend to.");
+                return;
+            }
+          
+            if (HealingCooldownTracker.IsOnBandageCooldown(from))
+            {
+                from.SendMessage("You cannot use veterinary supplies while bandages are in use.");
+                return;
+            }
+           
+            DateTime last;
+            if (!m_LastUse.TryGetValue(from, out last))
+                last = DateTime.MinValue;
+
+            double dex = from.Dex;
+            if (dex < 10.0)
+                dex = 10.0;
+            else if (dex > 150.0)
+                dex = 150.0;
+
+            double t = 1.0 - ((dex - 10.0) / 140.0);
+            TimeSpan cooldown = TimeSpan.FromSeconds(4.5 + (4.5 * t));
+
+            if (DateTime.UtcNow < last + cooldown)
+            {
+                TimeSpan remaining = (last + cooldown) - DateTime.UtcNow;
+                from.SendMessage("You must wait {0:F1} more seconds to use the Veterinary Supplies again.", remaining.TotalSeconds);
+                return;
+            }
+
+            m_LastUse[from] = DateTime.UtcNow;
+          
+            double vet = from.Skills[SkillName.Veterinary].Value;
+            double druid = from.Skills[SkillName.Druidism].Value;
+            double skillAvg = (vet + druid) / 2;
+
+            double successChance = skillAvg / 125.0; // 125 skill = 100% success
+            if(successChance > 1.0) {
+                successChance = 1.0;
+            }
+
+            if (Utility.RandomDouble() <= successChance)
+            {
+                from.SendMessage("You begin tending to your followers... ({0:F1}s)", cooldown.TotalSeconds);
+                from.PublicOverheadMessage(MessageType.Regular, 0x22, false, String.Format("You begin tending to your followers... ({0}s)", cooldown.TotalSeconds));
+                Timer.DelayCall(cooldown, new TimerStateCallback(ApplyVetSupplies), from);
+            }
+            else
+            {
+                from.SendMessage("You fumble with your supplies and fail to use them properly.");
+                from.FixedParticles(0x3735, 1, 30, 9502, EffectLayer.Waist);
+                from.PlaySound(0x5C); 
+            }
+            HealingCooldownTracker.SetVetSupplyCooldown(from, cooldown);
+        }
+
+        private void ApplyVetSupplies(object state)
+        {
+            Mobile from = state as Mobile;
+            if (from == null || from.Deleted)
+                return;
+
+            double vet = from.Skills[SkillName.Veterinary].Value;
+            double druid = from.Skills[SkillName.Druidism].Value;
+
+            double skillAvg = (vet + druid) / 2;
+
+            bool anyAffected = false;
+
+            IPooledEnumerable eable = from.GetMobilesInRange(2);
+            foreach (Mobile m in eable)
+            {
+                BaseCreature pet = m as BaseCreature;
+
+                if (pet != null && pet.Controlled && pet.ControlMaster == from)
+                {
+                    bool didSomething = false;
+
+                    if (pet.IsDeadPet && pet.IsBonded && vet > 80.0 && druid > 80.0)
+                    {
+                        double resChance = skillAvg / 200.0;
+                        if (Utility.RandomDouble() <= resChance)
+                        {
+                            if (from.CanSee(pet) && from.InLOS(pet) && pet.Map != null && pet.Map.CanFit(pet.Location, 16, false, false))
+                            {
+                                pet.ResurrectPet();
+                                pet.FixedEffect(0x376A, 10, 16);
+                                from.SendMessage("You have resurrected {0}.", pet.Name != null ? pet.Name : "your pet");
+                                anyAffected = true;
+                                continue;
+                            }
+                        }
+                    }
+
+                    if (pet.Alive && from.InRange(pet.Location, 2))
+                    {
+                        int healed = 0;
+
+                        if (pet.Poisoned && vet > 60.0 && druid > 60.0)
+                        {
+                            double cureChance = skillAvg / 150.0;
+                            if (Utility.RandomDouble() <= cureChance)
+                            {
+                                pet.CurePoison(from);
+                                didSomething = true;
+                            }
+                        }
+
+                        if (pet.Hits < pet.HitsMax)
+                        {
+                            double healChance = skillAvg / 100.0;
+                            if (Utility.RandomDouble() <= healChance)
+                            {
+                                double min = (druid / 2) + (vet / 2) + 25.0;
+					            double max = (druid / 2) + (vet / 2) + 50.0;
+                                double toHeal = min + (Utility.RandomDouble() * (max - min));
+
+                                pet.Heal((int)toHeal, from, false );
+                                healed = (int)toHeal;
+                                Effects.SendTargetParticles(pet, 0x376A, 10, 16, 5030, EffectLayer.Waist);
+                                didSomething = true;
+                            }
+                        }
+
+                        if (didSomething)
+                        {
+                            m_UsesRemaining--;
+                            from.SendMessage("{0} has been tended to.{1}", pet.Name != null ? pet.Name : "A pet", healed > 0 ? String.Format(" Healed for {0}.", healed) : "");
+                            anyAffected = true;
+                            if (m_UsesRemaining <= 0)
+                            {
+                                from.SendMessage("Your veterinary supplies have been used up.");
+                                Delete();
+                            }
+                            else
+                            {
+                                InvalidateProperties(); // update tooltip
+                            }
+                            from.CheckSkill( SkillName.Veterinary, 0.0, 120.0 );
+				            from.CheckSkill( SkillName.Druidism, 0.0, 120.0 );
+                        }
+                    }
+                }
+            }
+
+            eable.Free();
+
+            if (!anyAffected)
+            {
+                from.SendMessage("None of your followers needed attention.");
+            }
+        }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+            writer.Write((int)m_UsesRemaining);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+            m_UsesRemaining = reader.ReadInt();
+        }
+
+    }
+}

--- a/Data/Scripts/Mobiles/Civilized/Merchants/Farmer.cs
+++ b/Data/Scripts/Mobiles/Civilized/Merchants/Farmer.cs
@@ -51,6 +51,7 @@ namespace Server.Mobiles
 			{
 				public InternalBuyInfo()
 				{
+										ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( VeterinarySupplies )	 );
 					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.None,		ItemSalesInfo.Material.None,		ItemSalesInfo.Market.Farmer,		ItemSalesInfo.World.None,	null	 );
 					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.Armor,		ItemSalesInfo.Material.Metal,		ItemSalesInfo.Market.Cattle,		ItemSalesInfo.World.None,	null	 );
 				}
@@ -60,6 +61,7 @@ namespace Server.Mobiles
 			{
 				public InternalSellInfo()
 				{
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( VeterinarySupplies )	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.None,		ItemSalesInfo.Material.None,		ItemSalesInfo.Market.Farmer,		ItemSalesInfo.World.None,	null	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.Armor,		ItemSalesInfo.Material.Metal,		ItemSalesInfo.Market.Cattle,		ItemSalesInfo.World.None,	null	 );
 				}

--- a/Data/Scripts/Mobiles/Civilized/Merchants/Veterinarian.cs
+++ b/Data/Scripts/Mobiles/Civilized/Merchants/Veterinarian.cs
@@ -111,6 +111,7 @@ namespace Server.Mobiles
 			{
 				public InternalBuyInfo()
 				{
+					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( VeterinarySupplies )	 );
 					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( Bandage )	 );
 					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.Animals,	ItemSalesInfo.World.None,	null	 );
 					ItemInformation.GetSellList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.Stable,	ItemSalesInfo.World.None,	null	 );
@@ -121,6 +122,7 @@ namespace Server.Mobiles
 			{
 				public InternalSellInfo()
 				{
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( VeterinarySupplies )	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( Bandage )	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.Animals,	ItemSalesInfo.World.None,	null	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,		ItemSalesInfo.Material.All,		ItemSalesInfo.Market.Stable,	ItemSalesInfo.World.None,	null	 );

--- a/Data/Scripts/System/Commands/Player/VetSuppliesCommand.cs
+++ b/Data/Scripts/System/Commands/Player/VetSuppliesCommand.cs
@@ -1,0 +1,36 @@
+using Server;
+using Server.Commands;
+using Server.Mobiles;
+using Server.Items;
+
+namespace Server.Commands
+{
+	public class VetSuppliesCommand
+	{
+		public static void Initialize()
+		{
+			CommandSystem.Register("VetSupplies", AccessLevel.Player, new CommandEventHandler(Vet_OnCommand));
+		}
+
+		[Usage("VetSupplies")]
+		[Description("Uses veterinary supplies from your backpack if available.")]
+		private static void Vet_OnCommand(CommandEventArgs e)
+		{
+			Mobile from = e.Mobile;
+
+			Container pack = from.Backpack;
+			if (pack == null) return;
+
+			foreach (Item item in pack.Items)
+			{
+				if (item is VeterinarySupplies)
+				{
+					((VeterinarySupplies)item).OnDoubleClick(from);
+					return;
+				}
+			}
+
+			from.SendMessage("You do not have any veterinary supplies in your backpack.");
+		}
+	}
+}

--- a/Data/Scripts/System/Help/HelpGump.cs
+++ b/Data/Scripts/System/Help/HelpGump.cs
@@ -1740,7 +1740,7 @@ namespace Server.Engines.Help
 				+ "[spellhue ## - This command, following by a color reference hue number, will change all of your magery spell effects to that color. A value of '1' will normally render as '0' so avoid that setting as it will not produce the result you may want.<br><br>"
 				+ "[statistics - Shows you some statistics of the server.<br><br>"
 				+ "[wealth - Opens a small, horizontal bar showing your gold value for the various forms of currency and gold in your bank and backpack. Currency are items you would have a banker convert to gold for you (silver, copper, xormite, jewels, and crystals). If you put these items in your bank, you can update the values on the wealth bar by right clicking on it.<br><br>"
-
+				+ "[VetSupplies - automatically finds and uses veterinarian supplies from the character's inventory if they are there.<br><br>"
 				+ "<br><br>"
 
 				+ "Area Difficulty Levels: When you enter many dangerous areas, there will be a message to you that you entered a particular area. There may be a level of difficulty shown in parenthesis, that will give you an indication on the difficulty of the area. Below are the descriptions for each level.<br><br>"

--- a/Data/Scripts/System/Misc/HealingCooldownTracker.cs
+++ b/Data/Scripts/System/Misc/HealingCooldownTracker.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using Server;
+
+namespace Server
+{
+    public static class HealingCooldownTracker
+    {
+        private static Dictionary<Mobile, DateTime> m_BandageUsers = new Dictionary<Mobile, DateTime>();
+        private static Dictionary<Mobile, DateTime> m_VetSupplyUsers = new Dictionary<Mobile, DateTime>();
+
+        public static bool IsOnBandageCooldown(Mobile m)
+        {
+            DateTime last;
+            return m_BandageUsers.TryGetValue(m, out last) && DateTime.UtcNow < last;
+        }
+
+        public static bool IsOnVetSupplyCooldown(Mobile m)
+        {
+            DateTime last;
+            return m_VetSupplyUsers.TryGetValue(m, out last) && DateTime.UtcNow < last;
+        }
+
+        public static void SetBandageCooldown(Mobile m, TimeSpan cooldown)
+        {
+            m_BandageUsers[m] = DateTime.UtcNow + cooldown;
+        }
+
+        public static void SetVetSupplyCooldown(Mobile m, TimeSpan cooldown)
+        {
+            m_VetSupplyUsers[m] = DateTime.UtcNow + cooldown;
+        }
+
+        public static void Cleanup()
+        {
+            DateTime now = DateTime.UtcNow;
+
+            CleanupDict(m_BandageUsers, now);
+            CleanupDict(m_VetSupplyUsers, now);
+        }
+
+        private static void CleanupDict(Dictionary<Mobile, DateTime> dict, DateTime now)
+        {
+            List<Mobile> toRemove = null;
+
+            foreach (KeyValuePair<Mobile, DateTime> kvp in dict)
+            {
+                if (kvp.Value <= now)
+                {
+                    if (toRemove == null)
+                        toRemove = new List<Mobile>();
+
+                    toRemove.Add(kvp.Key);
+                }
+            }
+
+            if (toRemove != null)
+            {
+                foreach (Mobile m in toRemove)
+                    dict.Remove(m);
+            }
+        }
+    }
+}

--- a/Data/Scripts/System/Misc/ItemSales.cs
+++ b/Data/Scripts/System/Misc/ItemSales.cs
@@ -1484,7 +1484,8 @@ namespace Server
 			Wax = 65,
 			Witch = 66,
 			Wizard = 67,
-			All = 68
+			All = 68,
+			Veterinarian = 69 //nice
 		}
 
 		public static ItemSalesInfo[] m_SellingInfo = new ItemSalesInfo[]
@@ -1960,6 +1961,7 @@ namespace Server
 			new ItemSalesInfo( typeof(	BambooScreen	),	334	,	0	,	0	,	false	,	false	,	World.Orient	,	Category.None	,	Material.None	,	Market.Monk	),
 			new ItemSalesInfo( typeof(	Banana	),	2	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Farmer	),
 			new ItemSalesInfo( typeof(	Bandage	),	2	,	60	,	0	,	false	,	false	,	World.None	,	Category.Resource	,	Material.None	,	Market.Healer	),
+			new ItemSalesInfo( typeof(	VeterinarySupplies	),	100	,	60	,	0	,	false	,	false	,	World.None	,	Category.Resource	,	Material.None	,	Market.Veterinarian	),
 			new ItemSalesInfo( typeof(	Bandana	),	6	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.Cloth	,	Market.Tailor	),
 			new ItemSalesInfo( typeof(	DDRelicBanner	),	1	,	0	,	200	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Art	),
 			new ItemSalesInfo( typeof(	BannerDeed	),	5000	,	1	,	95	,	false	,	false	,	World.None	,	Category.Rare	,	Material.None	,	Market.Art	),


### PR DESCRIPTION
This new item can be bought from veterinarians and farmers.

On use, it will display a cooldown based on the users dexterity, and attempt to heal all pets in range. 

It cannot be used while bandages are being used, and bandages cannot be used while it is in use. 

adds the [VetSupplies command to automatically find and use them in your bag, if you have them. 

TODO:
find a better icon/hue for the item. 
implement a bufficon for it, if anyone wants to do so.
