### PR TITLE
adds enhancement stones that work with any weapon class, and removes sharpening stones from global loot tables

### DIFF
--- a/Data/Scripts/Items/Containers/Loot.cs
+++ b/Data/Scripts/Items/Containers/Loot.cs
@@ -669,9 +669,9 @@ namespace Server
 		private static Type[] m_RareItemTypes = new Type[]
 			{
 				typeof( SkeletonsKey ),			typeof( MagicalDyes ),
-				typeof( HeavySharpeningStone ),	typeof( ConsecratedSharpeningStone ),	typeof( MyCircusTentEastAddonDeed ),
+				typeof( HeavyEnhancementStone ),typeof( ConsecratedEnhancementStone ),	typeof( MyCircusTentEastAddonDeed ),
 				typeof( ManyArrows100 ),		typeof( ManyBolts100 ),					typeof( MyTentSouthAddonDeed ),
-				typeof( RoughSharpeningStone ),	typeof( DenseSharpeningStone ),			typeof( ElementalSharpeningStone ),
+				typeof( RoughEnhancementStone ),typeof( DenseEnhancementStone ),		typeof( ElementalEnhancementStone ),
 				typeof( ArtifactManual ),		typeof( light_dragon_brazier ), 		typeof( MoonStone ),
 				typeof( CrystallineJar ),		typeof( TrophyBase ),					typeof( DockingLantern ),
 				typeof( BoatBuild ),			typeof( TrapKit ),						typeof( MalletStake ), 
@@ -703,9 +703,9 @@ namespace Server
 		private static Type[] m_AdventurerRareItemTypes = new Type[]
 			{
 				typeof( SkeletonsKey ),			typeof( MagicalDyes ),					typeof( EtherealPowerScroll),
-				typeof( HeavySharpeningStone ),	typeof( ConsecratedSharpeningStone ),	typeof( SummonPrison ),
+				typeof( HeavyEnhancementStone ),typeof( ConsecratedEnhancementStone ),	typeof( SummonPrison ),
 				typeof( MagicPigment ),			typeof( RunicHammer ),					typeof( RunicSaw ),
-				typeof( RoughSharpeningStone ),	typeof( DenseSharpeningStone ),			typeof( ElementalSharpeningStone ),
+				typeof( RoughEnhancementStone ),typeof( DenseEnhancementStone ),		typeof( ElementalEnhancementStone ),
 				typeof( ArtifactManual ),		typeof( Runebook ),						typeof( FrankenJournalInBox ),
 				typeof( CrystallineJar ),		typeof( DockingLantern ),				typeof( RunicFletching ),
 				typeof( BoatBuild ),			typeof( MalletStake ), 					typeof( PetBondDeed ),

--- a/Data/Scripts/Items/Trades/Enhancement Stones/ConsecratedEnhancementStone.cs
+++ b/Data/Scripts/Items/Trades/Enhancement Stones/ConsecratedEnhancementStone.cs
@@ -1,0 +1,158 @@
+using System;
+using Server;
+using Server.Targeting;
+
+namespace Server.Items
+{
+	public class ConsecratedEnhancementStone : Item
+	{
+		private int i_Uses;
+		[CommandProperty( AccessLevel.GameMaster )]
+		public int Uses { get { return i_Uses; } set { i_Uses = value; InvalidateProperties(); } }
+
+		[Constructable] 
+		public ConsecratedEnhancementStone() : this( 5 )
+		{
+		}
+
+		[Constructable] 
+		public ConsecratedEnhancementStone( int uses ) : base( 0x1F14 ) 
+		{ 
+			Weight = 1.0;
+			i_Uses = uses;
+			Hue = 0x38C;
+			Name = "Consecrated Enhancement Stone";
+		} 
+
+		public override void GetProperties( ObjectPropertyList list )
+		{
+			base.GetProperties( list );
+
+			list.Add( 1060584, "{0}\t{1}", i_Uses.ToString(), "Uses" );
+		}
+		
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( IsChildOf( from.Backpack ) )
+			{
+				if ( Uses < 1 )
+				{
+					Delete();
+					from.SendMessage(32, "This have no charges so it's gone!");
+				}
+				from.SendMessage("Which weapon you want to try to enhance?");
+				from.Target = new ConsecratedEnhancementStoneTarget(this);
+			}
+			else
+				from.SendMessage("This must be in your backpack to use.");
+		}
+
+        public override void AddNameProperties(ObjectPropertyList list)
+		{
+            base.AddNameProperties(list);
+			list.Add( 1070722, "Can Increase A Weapon's Damage");
+			list.Add( 1049644, "Will Bless The Weapon"); // PARENTHESIS
+        }
+
+		public void Enhancement(Mobile from, object o)
+		{
+			if ( o is Item )
+			{
+				if ( !((Item)o).IsChildOf( from.Backpack ) )
+				{
+					from.SendMessage(32, "This must be in your backpack to enhance");
+				}
+				else if (o is BaseWeapon && ((BaseWeapon)o).IsChildOf(from.Backpack))
+				{
+					BaseWeapon weap = o as BaseWeapon;
+					int i_DI = weap.Attributes.WeaponDamage;
+					if (weap.Quality == WeaponQuality.Exceptional)
+						i_DI += 15;
+					if (i_DI >= 70)
+					{
+						from.SendMessage(32, "This weapon cannot be enhanced any further");
+						return;
+					}
+					else if (from.Skills[SkillName.Blacksmith].Value < 80.0)
+						from.SendMessage(32, "You need at least 80.0 blacksmith and 80.0 knightship to enhance weapons with this stone");
+					else if (from.Skills[SkillName.Knightship].Value < 80.0)
+						from.SendMessage(32, "You need at least 80.0 blacksmith and 80 knightship to enhance weapons with this stone");
+					else if ( !Deleted )
+					{
+						int bonus = Utility.Random((int)(from.Skills[SkillName.Blacksmith].Value/10));
+						if (bonus > 0)
+						{
+							if (70 < i_DI + bonus)
+								bonus = 70 - i_DI;
+							weap.Attributes.WeaponDamage += bonus;
+							weap.Consecrated = true;
+							weap.LootType = LootType.Blessed;
+							from.SendMessage(88, "You enhanced the weapon with {0} damange increase", bonus);
+						}
+						else
+							from.SendMessage(32, "You fail to enhance the weapon");
+						if (Uses <= 1)
+						{
+							from.SendMessage(32, "You used up the Enhancement stone");
+							Delete();
+						}
+						else
+						{
+							--Uses;
+							from.SendMessage(32, "You have {0} uses left", Uses);
+						}
+					}
+				}
+				else
+				{
+					from.SendMessage(32, "You can only enhance weapons");
+				}
+			}
+			else
+			{
+				from.SendMessage(32, "You cannot enhance that");
+			}
+		}
+
+		public ConsecratedEnhancementStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 ); // version
+
+			writer.Write( (int) i_Uses );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			i_Uses = reader.ReadInt();
+			if ( version == 0 ) { Serial sr_Owner = reader.ReadInt(); }
+		}
+	}
+
+	public class ConsecratedEnhancementStoneTarget : Target
+	{
+		private ConsecratedEnhancementStone sb_Blade;
+
+		public ConsecratedEnhancementStoneTarget(ConsecratedEnhancementStone blade) : base( 18, false, TargetFlags.None )
+		{
+			sb_Blade = blade;
+		}
+
+		protected override void OnTarget(Mobile from, object targeted)
+		{
+			if (sb_Blade.Deleted)
+				return;
+
+			sb_Blade.Enhancement(from, targeted);
+		}
+	}
+}

--- a/Data/Scripts/Items/Trades/Enhancement Stones/DenseEnhancementStone.cs
+++ b/Data/Scripts/Items/Trades/Enhancement Stones/DenseEnhancementStone.cs
@@ -1,0 +1,153 @@
+using System;
+using Server;
+using Server.Targeting;
+
+namespace Server.Items
+{
+	public class DenseEnhancementStone : Item
+	{
+		private int i_Uses;
+		[CommandProperty( AccessLevel.GameMaster )]
+		public int Uses { get { return i_Uses; } set { i_Uses = value; InvalidateProperties(); } }
+
+		[Constructable] 
+		public DenseEnhancementStone() : this( 5 )
+		{
+		}
+
+		[Constructable] 
+		public DenseEnhancementStone( int uses ) : base( 0x1F14 ) 
+		{ 
+			Weight = 1.0;
+			i_Uses = uses;
+			Hue = 0x38C;
+			Name = "Dense Enhancement Stone";
+		} 
+
+		public override void GetProperties( ObjectPropertyList list )
+		{
+			base.GetProperties( list );
+
+			list.Add( 1060584, "{0}\t{1}", i_Uses.ToString(), "Uses" );
+		}
+		
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( IsChildOf( from.Backpack ) )
+			{
+				if ( Uses < 1 )
+				{
+					Delete();
+					from.SendMessage(32, "This have no charges so it's gone!");
+				}
+				from.SendMessage("Which weapon you want to try to enhance?");
+				from.Target = new DenseEnhancementStoneTarget(this);
+			}
+			else
+				from.SendMessage("This must be in your backpack to use.");
+		}
+		
+        public override void AddNameProperties(ObjectPropertyList list)
+		{
+            base.AddNameProperties(list);
+			list.Add( 1070722, "Can Wondrously Increase a Weapon's Damage");
+        }
+
+		public void Enhancement(Mobile from, object o)
+		{
+			if ( o is Item )
+			{
+				if ( !((Item)o).IsChildOf( from.Backpack ) )
+				{
+					from.SendMessage(32, "This must be in your backpack to enhance");
+				}
+				else if (o is BaseWeapon && ((BaseWeapon)o).IsChildOf(from.Backpack))
+				{
+					BaseWeapon weap = o as BaseWeapon;
+					int i_DI = weap.Attributes.WeaponDamage;
+					if (weap.Quality == WeaponQuality.Exceptional)
+						i_DI += 15;
+					if (i_DI >= 100)
+					{
+						from.SendMessage(32, "This weapon cannot be enhanced any further");
+						return;
+					}
+					else if (from.Skills[SkillName.Blacksmith].Value < 100.0)
+						from.SendMessage(32, "You need at least 100.0 blacksmith to enhance weapons with this stone");
+					else if ( !Deleted )
+					{
+						int bonus = Utility.Random((int)(from.Skills[SkillName.Blacksmith].Value/10));
+						if (bonus > 0)
+						{
+							if (100 < i_DI + bonus)
+								bonus = 100 - i_DI;
+							weap.Attributes.WeaponDamage += bonus;
+							from.SendMessage(88, "You enhance the weapon with {0} damange increase", bonus);
+						}
+						else
+							from.SendMessage(32, "You fail to enhance the weapon");
+						if (Uses <= 1)
+						{
+							from.SendMessage(32, "You used up the enhancement stone");
+							Delete();
+						}
+						else
+						{
+							--Uses;
+							from.SendMessage(32, "You have {0} uses left", Uses);
+						}
+					}
+				}
+				else
+				{
+					from.SendMessage(32, "You cannot enhance that item.");
+				}
+			}
+			else
+			{
+				from.SendMessage(32, "You cannot enhance that.");
+			}
+		}
+
+		public DenseEnhancementStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 ); // version
+
+			writer.Write( (int) i_Uses );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			i_Uses = reader.ReadInt();
+			if ( version == 0 ) { Serial sr_Owner = reader.ReadInt(); }
+		}
+	}
+
+	public class DenseEnhancementStoneTarget : Target
+	{
+		private DenseEnhancementStone sb_Weapon;
+
+		public DenseEnhancementStoneTarget(DenseEnhancementStone weapon) : base( 18, false, TargetFlags.None )
+		{
+			sb_Weapon = weapon;
+		}
+
+		protected override void OnTarget(Mobile from, object targeted)
+		{
+			if (sb_Weapon.Deleted)
+				return;
+
+			sb_Weapon.Enhancement(from, targeted);
+		}
+	}
+}

--- a/Data/Scripts/Items/Trades/Enhancement Stones/ElementalEnhancementStone.cs
+++ b/Data/Scripts/Items/Trades/Enhancement Stones/ElementalEnhancementStone.cs
@@ -1,0 +1,154 @@
+using System;
+using Server;
+using Server.Targeting;
+
+namespace Server.Items
+{
+	public class ElementalEnhancementStone : Item
+	{
+		private int i_Uses;
+		[CommandProperty( AccessLevel.GameMaster )]
+		public int Uses { get { return i_Uses; } set { i_Uses = value; InvalidateProperties(); } }
+
+		[Constructable] 
+		public ElementalEnhancementStone() : this( 5 )
+		{
+		}
+
+		[Constructable] 
+		public ElementalEnhancementStone( int uses ) : base( 0x1F14 ) 
+		{ 
+			Weight = 1.0;
+			i_Uses = uses;
+			Hue = 0x38C;
+			Name = "Elemental Enhancement Stone";
+		} 
+
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( IsChildOf( from.Backpack ) )
+			{
+				if ( Uses < 1 )
+				{
+					Delete();
+					from.SendMessage(32, "This have no charges so it's gone!");
+				}
+				from.SendMessage("Which weapon you want to try to enhance?");
+				from.Target = new ElementalEnhancementStoneTarget(this);
+			}
+			else
+				from.SendMessage("This must be in your backpack to use.");
+		}
+		
+        public override void AddNameProperties(ObjectPropertyList list)
+		{
+            base.AddNameProperties(list);
+			list.Add( 1070722, "Can Increase A Weapon's Damage");
+			list.Add( 1049644, "Even Damage To All Defenses"); // PARENTHESIS
+        }
+
+		public void Enhancement(Mobile from, object o)
+		{
+			if ( o is Item )
+			{
+				if ( !((Item)o).IsChildOf( from.Backpack ) )
+				{
+					from.SendMessage(32, "This must be in your backpack to enhance");
+				}
+				else if (o is BaseWeapon && ((BaseWeapon)o).IsChildOf(from.Backpack))
+				{
+					BaseWeapon weap = o as BaseWeapon;
+					int i_DI = weap.Attributes.WeaponDamage;
+					if (weap.Quality == WeaponQuality.Exceptional)
+						i_DI += 15;
+					if (i_DI >= 70)
+					{
+						from.SendMessage(32, "This weapon cannot be enhanced any further");
+						return;
+					}
+					else if (from.Skills[SkillName.Blacksmith].Value < 100.0)
+						from.SendMessage(32, "You need at least 100.0 blacksmith and magery to enhance weapons with elemental power");
+					else if (from.Skills[SkillName.Magery].Value < 100.0)
+						from.SendMessage(32, "You need at least 100.0 blacksmith and magery to enhance weapons with elemental power");
+					else if ( !Deleted )
+					{
+						int bonus = Utility.Random((int)(from.Skills[SkillName.Blacksmith].Value/20));
+						if (bonus > 0)
+						{
+							if (70 < i_DI + bonus)
+								bonus = 70 - i_DI;
+							weap.Attributes.WeaponDamage += bonus;
+							weap.AosElementDamages.Fire = 20;
+							weap.AosElementDamages.Cold = 20;
+							weap.AosElementDamages.Poison = 20;
+							weap.AosElementDamages.Energy = 20;
+							weap.AosElementDamages.Physical = 20;
+							from.SendMessage(88, "You enhanced the weapon with {0} elemental damage increase", bonus);
+						}
+						else
+							from.SendMessage(32, "You fail to enhanced the weapon");
+						if (Uses <= 1)
+						{
+							from.SendMessage(32, "You used up the enhancement stone");
+							Delete();
+						}
+						else
+						{
+							--Uses;
+							from.SendMessage(32, "You have {0} uses left", Uses);
+						}
+					}
+				}
+				else
+				{
+					from.SendMessage(32, "You cannot enhance that item.");
+				}
+			}
+			else
+			{
+				from.SendMessage(32, "You can only enhance edged weapons");
+			}
+		}
+
+		public ElementalEnhancementStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 ); // version
+
+			writer.Write( (int) i_Uses );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			i_Uses = reader.ReadInt();
+			if ( version == 0 ) { Serial sr_Owner = reader.ReadInt(); }
+		}
+	}
+
+	public class ElementalEnhancementStoneTarget : Target
+	{
+		private ElementalEnhancementStone sb_Blade;
+
+		public ElementalEnhancementStoneTarget(ElementalEnhancementStone blade) : base( 18, false, TargetFlags.None )
+		{
+			sb_Blade = blade;
+		}
+
+		protected override void OnTarget(Mobile from, object targeted)
+		{
+			if (sb_Blade.Deleted)
+				return;
+
+			sb_Blade.Enhancement(from, targeted);
+		}
+	}
+}

--- a/Data/Scripts/Items/Trades/Enhancement Stones/HeavyEnhancementStone.cs
+++ b/Data/Scripts/Items/Trades/Enhancement Stones/HeavyEnhancementStone.cs
@@ -1,0 +1,153 @@
+using System;
+using Server;
+using Server.Targeting;
+
+namespace Server.Items
+{
+	public class HeavyEnhancementStone : Item
+	{
+		private int i_Uses;
+		[CommandProperty( AccessLevel.GameMaster )]
+		public int Uses { get { return i_Uses; } set { i_Uses = value; InvalidateProperties(); } }
+
+		[Constructable] 
+		public HeavyEnhancementStone() : this( 5 )
+		{
+		}
+
+		[Constructable] 
+		public HeavyEnhancementStone( int uses ) : base( 0x1F14 ) 
+		{ 
+			Weight = 1.0;
+			i_Uses = uses;
+			Hue = 0x38C;
+			Name = "Heavy Enhancement Stone";
+		} 
+
+		public override void GetProperties( ObjectPropertyList list )
+		{
+			base.GetProperties( list );
+
+			list.Add( 1060584, "{0}\t{1}", i_Uses.ToString(), "Uses" );
+		}
+		
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( IsChildOf( from.Backpack ) )
+			{
+				if ( Uses < 1 )
+				{
+					Delete();
+					from.SendMessage(32, "This have no charges so it's gone!");
+				}
+				from.SendMessage("Which weapon you want to try to enhance?");
+				from.Target = new HeavyEnhancementStoneTarget(this);
+			}
+			else
+				from.SendMessage("This must be in your backpack to use.");
+		}
+		
+        public override void AddNameProperties(ObjectPropertyList list)
+		{
+            base.AddNameProperties(list);
+			list.Add( 1070722, "Can Wondrously Increase a Weapon's Damage");
+        }
+
+		public void Enhancement(Mobile from, object o)
+		{
+			if ( o is Item )
+			{
+				if ( !((Item)o).IsChildOf( from.Backpack ) )
+				{
+					from.SendMessage(32, "This must be in your backpack to enhance");
+				}
+				else if (o is BaseWeapon && ((BaseWeapon)o).IsChildOf(from.Backpack))
+				{
+					BaseWeapon weap = o as BaseWeapon;
+					int i_DI = weap.Attributes.WeaponDamage;
+					if (weap.Quality == WeaponQuality.Exceptional)
+						i_DI += 15;
+					if (i_DI >= 80)
+					{
+						from.SendMessage(32, "This weapon cannot be enhanced any further");
+						return;
+					}
+					else if (from.Skills[SkillName.Blacksmith].Value < 80.0)
+						from.SendMessage(32, "You need at least 80.0 blacksmith to enhance weapons with this stone");
+					else if ( !Deleted )
+					{
+						int bonus = Utility.Random((int)(from.Skills[SkillName.Blacksmith].Value/10));
+						if (bonus > 0)
+						{
+							if (80 < i_DI + bonus)
+								bonus = 80 - i_DI;
+							weap.Attributes.WeaponDamage += bonus;
+							from.SendMessage(88, "You enhance the weapon with {0} damange increase", bonus);
+						}
+						else
+							from.SendMessage(32, "You fail to enhance the weapon");
+						if (Uses <= 1)
+						{
+							from.SendMessage(32, "You used up the enhancement stone");
+							Delete();
+						}
+						else
+						{
+							--Uses;
+							from.SendMessage(32, "You have {0} uses left", Uses);
+						}
+					}
+				}
+				else
+				{
+					from.SendMessage(32, "You cannot enhance that item.");
+				}
+			}
+			else
+			{
+				from.SendMessage(32, "You cannot enhance that.");
+			}
+		}
+
+		public HeavyEnhancementStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 ); // version
+
+			writer.Write( (int) i_Uses );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			i_Uses = reader.ReadInt();
+			if ( version == 0 ) { Serial sr_Owner = reader.ReadInt(); }
+		}
+	}
+
+	public class HeavyEnhancementStoneTarget : Target
+	{
+		private HeavyEnhancementStone sb_Weapon;
+
+		public HeavyEnhancementStoneTarget(HeavyEnhancementStone weapon) : base( 18, false, TargetFlags.None )
+		{
+			sb_Weapon = weapon;
+		}
+
+		protected override void OnTarget(Mobile from, object targeted)
+		{
+			if (sb_Weapon.Deleted)
+				return;
+
+			sb_Weapon.Enhancement(from, targeted);
+		}
+	}
+}

--- a/Data/Scripts/Items/Trades/Enhancement Stones/RoughEnhancementStone.cs
+++ b/Data/Scripts/Items/Trades/Enhancement Stones/RoughEnhancementStone.cs
@@ -1,0 +1,153 @@
+using System;
+using Server;
+using Server.Targeting;
+
+namespace Server.Items
+{
+	public class RoughEnhancementStone : Item
+	{
+		private int i_Uses;
+		[CommandProperty( AccessLevel.GameMaster )]
+		public int Uses { get { return i_Uses; } set { i_Uses = value; InvalidateProperties(); } }
+
+		[Constructable] 
+		public RoughEnhancementStone() : this( 5 )
+		{
+		}
+
+		[Constructable] 
+		public RoughEnhancementStone( int uses ) : base( 0x1F14 ) 
+		{ 
+			Weight = 1.0;
+			i_Uses = uses;
+			Hue = 0x38C;
+			Name = "Rough Enhancement Stone";
+		} 
+
+		public override void GetProperties( ObjectPropertyList list )
+		{
+			base.GetProperties( list );
+
+			list.Add( 1060584, "{0}\t{1}", i_Uses.ToString(), "Uses" );
+		}
+		
+		public override void OnDoubleClick( Mobile from )
+		{
+			if ( IsChildOf( from.Backpack ) )
+			{
+				if ( Uses < 1 )
+				{
+					Delete();
+					from.SendMessage(32, "This have no charges so it's gone!");
+				}
+				from.SendMessage("Which weapon you want to try to enhance?");
+				from.Target = new RoughEnhancementStoneTarget(this);
+			}
+			else
+				from.SendMessage("This must be in your backpack to use.");
+		}
+		
+        public override void AddNameProperties(ObjectPropertyList list)
+		{
+            base.AddNameProperties(list);
+			list.Add( 1070722, "Can Wondrously Increase a Weapon's Damage");
+        }
+
+		public void Enhancement(Mobile from, object o)
+		{
+			if ( o is Item )
+			{
+				if ( !((Item)o).IsChildOf( from.Backpack ) )
+				{
+					from.SendMessage(32, "This must be in your backpack to enhance");
+				}
+				else if (o is BaseWeapon && ((BaseWeapon)o).IsChildOf(from.Backpack))
+				{
+					BaseWeapon weap = o as BaseWeapon;
+					int i_DI = weap.Attributes.WeaponDamage;
+					if (weap.Quality == WeaponQuality.Exceptional)
+						i_DI += 15;
+					if (i_DI >= 60)
+					{
+						from.SendMessage(32, "This weapon cannot be enhanced any further");
+						return;
+					}
+					else if (from.Skills[SkillName.Blacksmith].Value < 60.0)
+						from.SendMessage(32, "You need at least 60.0 blacksmith to enhance weapons with this stone");
+					else if ( !Deleted )
+					{
+						int bonus = Utility.Random((int)(from.Skills[SkillName.Blacksmith].Value/10));
+						if (bonus > 0)
+						{
+							if (60 < i_DI + bonus)
+								bonus = 60 - i_DI;
+							weap.Attributes.WeaponDamage += bonus;
+							from.SendMessage(88, "You enhance the weapon with {0} damange increase", bonus);
+						}
+						else
+							from.SendMessage(32, "You fail to enhance the weapon");
+						if (Uses <= 1)
+						{
+							from.SendMessage(32, "You used up the enhancement stone");
+							Delete();
+						}
+						else
+						{
+							--Uses;
+							from.SendMessage(32, "You have {0} uses left", Uses);
+						}
+					}
+				}
+				else
+				{
+					from.SendMessage(32, "You cannot enhance that item.");
+				}
+			}
+			else
+			{
+				from.SendMessage(32, "You cannot enhance that.");
+			}
+		}
+
+		public RoughEnhancementStone( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 ); // version
+
+			writer.Write( (int) i_Uses );
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			i_Uses = reader.ReadInt();
+			if ( version == 0 ) { Serial sr_Owner = reader.ReadInt(); }
+		}
+	}
+
+	public class RoughEnhancementStoneTarget : Target
+	{
+		private RoughEnhancementStone sb_Weapon;
+
+		public RoughEnhancementStoneTarget(RoughEnhancementStone weapon) : base( 18, false, TargetFlags.None )
+		{
+			sb_Weapon = weapon;
+		}
+
+		protected override void OnTarget(Mobile from, object targeted)
+		{
+			if (sb_Weapon.Deleted)
+				return;
+
+			sb_Weapon.Enhancement(from, targeted);
+		}
+	}
+}


### PR DESCRIPTION
Enhancement stones that work with any weapon will now drop. They work exactly like sharpening stones used to, except that macing/fencing/marksmanship weapons also benefit from them. 
Sharpening stones remain in the codebase for legacy maintenance reasons. 
