### PR TITLE
adds the contraband system (on the correct branch)

### DIFF
--- a/Data/Scripts/Items/Containers/ContrabandBox.cs
+++ b/Data/Scripts/Items/Containers/ContrabandBox.cs
@@ -5,9 +5,6 @@ using Server.Mobiles;
 
 namespace Server.Items
 {
-    /// <summary>
-    /// Base class for contraband boxes. Unopenable, immovable, with a default graphic.
-    /// </summary>
     public abstract class ContrabandBox : Item
     {
         public ContrabandBox(int itemID, int hue) : base(itemID)

--- a/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
+++ b/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
@@ -181,7 +181,7 @@ namespace Server.Mobiles
 
 	    		if (pm == null || pm.NpcGuild != NpcGuild.ThievesGuild)
 	    		{
-	    		    SayTo(from, "Sorry, I do not do business with those I don't trust. Guild members only, {0}.", from.Name);
+	    		    SayTo(from, "Sorry but I do not do business with those I don't trust. Guild members only, {0}.", from.Name);
 	    		    return false;
 	    		}
 

--- a/Data/Scripts/System/Misc/ContrabandSystem.cs
+++ b/Data/Scripts/System/Misc/ContrabandSystem.cs
@@ -17,9 +17,6 @@ namespace Server.Systems
 
     public static class ContrabandSystem
     {
-        /// <summary>
-        /// Call this after a successful steal attempt to possibly award a contraband box.
-        /// </summary>
         public static void TryGiveContraband(Mobile thief, Mobile victim)
         {
             if (thief == null || victim == null)

--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -413,6 +413,7 @@ namespace Server.SkillHandlers
 					from.AddToBackpack( stolen );
 
 					StolenItem.Add( stolen, m_Thief, root as Mobile );
+					//contraband boxes can only be found if the thief suceeded at stealing something
 					Mobile m = target as Mobile;
 					if (m != null)
 					{


### PR DESCRIPTION
This adds the contraband system to the game. 

When a player succeeds at stealing something, there's a chance based on stealing skill and luck to get a contraband box. 

These boxes can be handed to the guildmaster of the thieves guild (by guild members) in exchange for rewards.

A random sentence is generated by each, depending on box rarity:
![image](https://github.com/user-attachments/assets/d0b4d07d-b49f-425e-9a78-7ecf7582e904)

upon handing in the box, the player receives a reward bag that scales with the box rarity:
![image](https://github.com/user-attachments/assets/37cd0479-bb78-4a4e-a43c-2e22097eea1d)


There's a one hour cooldown between rewards:
![image](https://github.com/user-attachments/assets/2e23b807-5fc7-49ec-a076-a72815cc12e5)

The boxes are somewhat rare, and their dropchance is influenced by the fame of the monster being stolen. Only the strongest monsters have a chance of awarding the best boxes, and even then those are very rare, as shown here: 

![image](https://github.com/user-attachments/assets/999d2053-0d67-40ae-87be-386c4c2c70c8)


The goal of this change is to provide thieves with incentives for actively using their stealing skill while adventuring. 