### PR TITLE
adds the contraband system to the game

### DIFF
--- a/Data/Scripts/Items/Containers/ContrabandBox.cs
+++ b/Data/Scripts/Items/Containers/ContrabandBox.cs
@@ -1,0 +1,182 @@
+using System;
+using Server;
+using Server.Items;
+using Server.Mobiles;
+
+namespace Server.Items
+{
+    public abstract class ContrabandBox : Item
+    {
+        public ContrabandBox(int itemID, int hue) : base(itemID)
+        {
+            Weight    = 5.0;
+            Movable   = true;
+        }
+
+        public override string DefaultDescription{ get{ return "This box contains illegal goods. They can be given to the guildmaster in the thieves guild, who will know who might be interested in the contents of such ill gotten goods."; } }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (from != null && !from.Deleted)
+                from.SendMessage("You cannot open this contraband box.");
+        }
+
+        public ContrabandBox(Serial serial) : base(serial) { }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class CommonContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public CommonContrabandBox() : base(0xE7C, 0)
+        {
+            Name = "Common Contraband Box";
+            Hue = 0x835;
+        }
+
+        public CommonContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class UncommonContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public UncommonContrabandBox() : base(0xE7C, 0x59)
+        {
+            Name = "Uncommon Contraband Box";
+            Hue = 0x8B0;
+        }
+
+        public UncommonContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class RareContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public RareContrabandBox() : base(0xE7C, 0x4BE)
+        {
+            Name = "Rare Contraband Box";
+            Hue = 0x89B;
+        }
+
+        public RareContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class VeryRareContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public VeryRareContrabandBox() : base(0xE7C, 0x489)
+        {
+            Name = "Very Rare Contraband Box";
+            Hue = 0x88E;
+        }
+
+        public VeryRareContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class ExtremelyRareContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public ExtremelyRareContrabandBox() : base(0xE7C, 0x8A5)
+        {
+            Name = "Extremely Rare Contraband Box";
+            Hue = 0x86C;
+        }
+
+        public ExtremelyRareContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+
+    [Flipable(0xE7C, 0xE7D)]
+    public class LegendaryContrabandBox : ContrabandBox
+    {
+        [Constructable]
+        public LegendaryContrabandBox() : base(0xE7C, 0xAA0)
+        {
+            Name = "Legendary Contraband Box";
+            Hue = 0x21;
+        }
+
+        public LegendaryContrabandBox(Serial serial) : base(serial) { }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
+++ b/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
@@ -15,6 +15,8 @@ namespace Server.Mobiles
 	{
 		public override NpcGuild NpcGuild{ get{ return NpcGuild.ThievesGuild; } }
 
+		private static Dictionary<Mobile, DateTime> m_LastContrabandTurnIn = new Dictionary<Mobile, DateTime>();
+
 		[Constructable]
 		public ThiefGuildmaster() : base( "thief" )
 		{
@@ -153,5 +155,215 @@ namespace Server.Mobiles
 			base.Deserialize( reader );
 			int version = reader.ReadInt();
 		}
+
+		public override bool OnDragDrop( Mobile from, Item dropped )
+		{
+			if(dropped is Gold || dropped is BankCheck)
+			{
+				ProcessGuild( from, dropped );
+			}
+			else if (dropped is ContrabandBox)
+    		{
+				DateTime lastTime;
+				PlayerMobile pm = (PlayerMobile)from;
+        		if (m_LastContrabandTurnIn.TryGetValue(from, out lastTime))
+        		{
+        		    TimeSpan remaining = (lastTime + TimeSpan.FromHours(1)) - DateTime.UtcNow;
+
+        		    if (remaining > TimeSpan.Zero)
+        		    {
+        		        SayTo(from, "I'm still waiting on the buyer for the last one. Give me about {0} minute{1}.",
+        		            (int)Math.Ceiling(remaining.TotalMinutes),
+        		            remaining.TotalMinutes > 1 ? "s" : "");
+        		        return false;
+        		    }
+        		}
+
+	    		if (pm == null || pm.NpcGuild != NpcGuild.ThievesGuild)
+	    		{
+	    		    SayTo(from, "Sorry but I do not do business with those I don't trust. Guild members only, {0}.", from.Name);
+	    		    return false;
+	    		}
+
+        		ContrabandBox box = (ContrabandBox)dropped;
+        		string[] messages = GetMessageForBox(box);
+
+    			if (messages.Length > 0)
+    		    	{
+    		    	    SayTo(from, messages[Utility.Random(messages.Length)]);
+    		    	    dropped.Delete(); 
+						m_LastContrabandTurnIn[from] = DateTime.UtcNow;
+
+						RewardPlayer(from,box);
+    		    	    return true;
+    		    	}
+    		}
+			return base.OnDragDrop( from, dropped );
+		}
+
+		private string[] GetMessageForBox(ContrabandBox box)
+		{
+			if (box is LegendaryContrabandBox)
+			{
+				return new string[]
+				{
+					"We will be rich my friend, rich beyond our wildest dreams!",
+					"I can't believe you managed to snatch one of those! You did the guild a great favor, my friend!",
+					"They'll be telling stories about this one in every tavern for years to come!",
+					"This is the score of a lifetime, friend!"
+				};
+			}
+			else if (box is ExtremelyRareContrabandBox)
+			{
+				return new string[]
+				{
+					"This will take all my kids through college!",
+					"I might be looking to retire after I pass this one along.",
+					"Careful with that one—it might be a lot of trouble. I hope no one can trace this back to us",
+					"Top-tier stuff, I'll need to make some calls. You focus on celebrating. You earned it.",
+					"This is worth its weight in platinum.",
+					"You might just be the best thief in the realm!"
+				};
+			}
+			else if (box is VeryRareContrabandBox || box is RareContrabandBox)
+			{
+				return new string[]
+				{
+					"You make the guild proud, my friend.",
+					"Ah...This will fetch a nice price.",
+					"It's not often you see these around... I know someone that will be very happy to receive this.",
+					"A find like this doesn't come around often.",
+					"I'm sure that this one will a some noble sweat...",
+					"It's got that special shine to it...Doesn't it?"
+				};
+			}
+			else if (box is UncommonContrabandBox || box is CommonContrabandBox)
+			{
+				return new string[]
+				{
+					"A day's work for a day's pay, eh?",
+					"I think I know someone that might be interested in this.",
+					"Not bad for an honest day's crime.",
+					"Keeps the network running, these little ones.",
+					"I don't think that this one will be missed too much."
+				};
+			}
+
+			return new string[0];
+		}
+
+		private static void RewardPlayer(Mobile mobile, Item box)
+		{
+		    if (mobile == null || box == null)
+		        return;
+
+		    Container rewardBag = new Bag();
+		    rewardBag.Name = "Ill gotten gains";
+		    rewardBag.Hue = Utility.RandomDyedHue();
+
+		    int luck = mobile.Luck;
+
+		    if (box is CommonContrabandBox)
+		    {
+		        int min = 50, max = 250;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new Gold(amount));
+		        rewardBag.DropItem(Loot.RandomMagicalItem());
+		        rewardBag.DropItem(Loot.RandomPotion(4, false));
+		    }
+		    else if (box is UncommonContrabandBox)
+		    {
+		        int min = 250, max = 450;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new Gold(amount));
+		        rewardBag.DropItem(Loot.RandomMagicalItem());
+		        rewardBag.DropItem(Loot.RandomMagicalItem());
+		        rewardBag.DropItem(Loot.RandomPotion(8, false));
+		    }
+		    else if (box is RareContrabandBox)
+		    {
+		        int min = 550, max = 1090;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new Gold(amount));
+		        rewardBag.DropItem(Loot.RandomPotion(12, false));
+
+		        if (Utility.Random(5) == 0)
+		            rewardBag.DropItem(PowerScroll.CreateRandom(105, 110));
+
+		        if (Utility.Random(5) == 0)
+		            rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 15));
+
+		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
+		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		    }
+		    else if (box is VeryRareContrabandBox)
+		    {
+		        int min = 1540, max = 2800;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new Gold(amount));
+
+		        if (Utility.RandomBool())
+		            rewardBag.DropItem(PowerScroll.CreateRandom(105, 110));
+		        else
+		            rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 15));
+
+		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
+		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		    }
+		    else if (box is ExtremelyRareContrabandBox)
+		    {
+		        int min = 3500, max = 6600;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new BankCheck(amount));
+
+		        rewardBag.DropItem(PowerScroll.CreateRandom(105, 115));
+		        rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 25));
+
+		        if (Utility.Random(5) == 0)
+		            rewardBag.DropItem(Loot.RandomArty());
+
+		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
+		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		    }
+		    else if (box is LegendaryContrabandBox)
+		    {
+		        int min = 10000, max = 12000;
+		        int amount = GetGoldByLuck(min, max, luck);
+		        rewardBag.DropItem(new BankCheck(amount));
+
+		        Item arty = Loot.RandomArty();
+		        
+				if (arty != null)
+		            rewardBag.DropItem(arty);
+
+		        rewardBag.DropItem(PowerScroll.CreateRandom(110, 120));
+		        rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 35));
+		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
+		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
+		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		    }
+		    mobile.AddToBackpack(rewardBag);
+			mobile.SendMessage("The Guildmaster rewards you for your skill and discretion.");
+			Effects.PlaySound(mobile.Location, mobile.Map, 0x32);
+		}
+
+
+		private static int GetGoldByLuck(int min, int max, int luck)
+		{
+		    int randomValue = Utility.RandomMinMax(min, max);
+
+		    if (luck <= 0)
+		        return randomValue;
+
+		    if (luck >= 2000)
+		        return max;
+
+		    double luckFactor = Math.Min(luck, 2000) / 2000.0;
+		    int adjustedValue = min + (int)((max - min) * luckFactor);
+
+		    return Math.Max(randomValue, adjustedValue);
+		}
+
 	}
 }

--- a/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
+++ b/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
@@ -63,6 +63,12 @@ namespace Server.Mobiles
 				{
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.Thief,		ItemSalesInfo.World.None,	null	 );
 					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( DisguiseKit )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( CommonContrabandBox )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( UncommonContrabandBox )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( RareContrabandBox )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( VeryRareContrabandBox )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( ExtremelyRareContrabandBox )	 );
+					ItemInformation.GetBuysList( m_Merchant, this, 	ItemSalesInfo.Category.All,			ItemSalesInfo.Material.All,		ItemSalesInfo.Market.All,		ItemSalesInfo.World.None,	typeof( LegendaryContrabandBox )	 );
 				}
 			}
 		}

--- a/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
+++ b/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
@@ -346,6 +346,25 @@ namespace Server.Mobiles
 		    mobile.AddToBackpack(rewardBag);
 			mobile.SendMessage("The Guildmaster rewards you for your skill and discretion.");
 			Effects.PlaySound(mobile.Location, mobile.Map, 0x32);
+
+			int fame = 0;
+
+			if (box is CommonContrabandBox)
+			    fame = Utility.RandomMinMax(10, 50);
+			else if (box is UncommonContrabandBox)
+			    fame = Utility.RandomMinMax(60, 120);
+			else if (box is RareContrabandBox)
+			    fame = Utility.RandomMinMax(130, 190);
+			else if (box is VeryRareContrabandBox)
+			    fame = Utility.RandomMinMax(250, 350);
+			else if (box is ExtremelyRareContrabandBox)
+			    fame = Utility.RandomMinMax(600, 800);
+			else if (box is LegendaryContrabandBox)
+			    fame = Utility.RandomMinMax(1200, 1800);
+
+			Titles.AwardFame(mobile, fame, false);
+			LoggingFunctions.LogStandard( mobile, "has smuggled a " + box.Name + "!" );
+
 		}
 
 

--- a/Data/Scripts/System/Misc/ContrabandSystem.cs
+++ b/Data/Scripts/System/Misc/ContrabandSystem.cs
@@ -1,0 +1,120 @@
+using System;
+using Server;
+using Server.Mobiles;
+using Server.Items;
+
+namespace Server.Systems
+{
+    public enum ContrabandRarity
+    {
+        Common,
+        Uncommon,
+        Rare,
+        VeryRare,
+        ExtremelyRare,
+        Legendary
+    }
+
+    public static class ContrabandSystem
+    {
+        public static void TryGiveContraband(Mobile thief, Mobile victim)
+        {
+            if (thief == null || victim == null)
+                return;
+
+            // Base chance: stealing skill / 10
+            double stealSkill = thief.Skills[SkillName.Stealing].Value;
+            // Luck bonus: 2000 luck = +10% => luck / 20000
+            double luckBonus;
+            if (thief.Luck <= 0)
+            {
+                luckBonus = 0;
+            } 
+            else if (thief.Luck > 2000) 
+            {
+                luckBonus = 10.0;
+            } 
+            else
+            {
+                luckBonus = thief.Luck / 20000.0; 
+            }
+
+            double chance = (stealSkill / 10.0) + luckBonus;
+
+            // Roll for any contraband
+            if (Utility.RandomDouble() * 100.0 > chance)
+                return;
+
+            // Determine rarity
+            ContrabandRarity rarity = DetermineRarity(victim.Fame);
+
+            // Create and award box
+            Item box = CreateContrabandBox(rarity);
+            thief.AddToBackpack(box);
+            thief.SendMessage("You have acquired a {0} contraband box!", rarity);
+            Effects.PlaySound(thief.Location, thief.Map, 0x32);
+        }
+
+        private static ContrabandRarity DetermineRarity(int fame)
+        {
+            double roll = Utility.RandomDouble() * 100.0;
+
+            if (fame >= 15000)
+            {
+                if (roll <  4.0) return ContrabandRarity.Legendary;
+                if (roll <  8.0) return ContrabandRarity.ExtremelyRare;
+                if (roll <  16.0) return ContrabandRarity.VeryRare;
+                if (roll <  32.0) return ContrabandRarity.Rare;
+                return ContrabandRarity.Uncommon;
+            }
+            else if (fame >= 7500)
+            {
+                if (roll <  2.0) return ContrabandRarity.Legendary;
+                if (roll <  4.0) return ContrabandRarity.ExtremelyRare;
+                if (roll <  8.0) return ContrabandRarity.VeryRare;
+                if (roll <  16.0) return ContrabandRarity.Rare;
+                if (roll <  48.0) return ContrabandRarity.Uncommon;
+                return ContrabandRarity.Common;
+            }
+            else if (fame >= 5000)
+            {
+                if (roll <  2.0) return ContrabandRarity.ExtremelyRare;
+                if (roll <  4.0) return ContrabandRarity.VeryRare;
+                if (roll <  8.0) return ContrabandRarity.Rare;
+                if (roll <  32.0) return ContrabandRarity.Uncommon;
+                return ContrabandRarity.Common;
+            }
+            else if (fame >= 1000)
+            {
+                if (roll <  2.0) return ContrabandRarity.VeryRare;
+                if (roll <  4.0) return ContrabandRarity.Rare;
+                if (roll <  24.0) return ContrabandRarity.Uncommon;
+                return ContrabandRarity.Common;
+            }
+            else
+            {
+                if (roll <  8.0) return ContrabandRarity.Uncommon;
+                return ContrabandRarity.Common;
+            }
+        }
+
+        private static Item CreateContrabandBox(ContrabandRarity rarity)
+        {
+            Item box;
+            switch (rarity)
+            {
+                case ContrabandRarity.Legendary:     box = new LegendaryContrabandBox(); break;
+                case ContrabandRarity.ExtremelyRare: box = new ExtremelyRareContrabandBox(); break;
+                case ContrabandRarity.VeryRare:      box = new VeryRareContrabandBox(); break;
+                case ContrabandRarity.Rare:          box = new RareContrabandBox(); break;
+                case ContrabandRarity.Uncommon:      box = new UncommonContrabandBox(); break;
+                default:                             box = new CommonContrabandBox(); break;
+            }
+
+            box.Name     = String.Format("{0} Contraband Box", rarity);
+            box.Weight   = 5.0;
+            box.Movable  = true;
+            return box;
+        }
+    }
+}

--- a/Data/Scripts/System/Misc/ItemSales.cs
+++ b/Data/Scripts/System/Misc/ItemSales.cs
@@ -1937,6 +1937,13 @@ namespace Server
 			new ItemSalesInfo( typeof(	Artifact_BladeOfTheWilds	),	5000	,	0	,	0	,	false	,	false	,	World.None	,	Category.Artifact	,	Material.None	,	Market.None	),
 			new ItemSalesInfo( typeof(	Artifact_WhistleofthePiper	),	5000	,	0	,	0	,	false	,	false	,	World.None	,	Category.Artifact	,	Material.None	,	Market.None	),
 
+			// contraband boxes
+			new ItemSalesInfo( typeof(	CommonContrabandBox	),	50	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
+			new ItemSalesInfo( typeof(	UncommonContrabandBox	),	150	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
+			new ItemSalesInfo( typeof(	RareContrabandBox	),	350	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
+			new ItemSalesInfo( typeof(	VeryRareContrabandBox	),	850	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
+			new ItemSalesInfo( typeof(	ExtremelyRareContrabandBox	),	1200	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
+			new ItemSalesInfo( typeof(	LegendaryContrabandBox	),	10000	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.None	),
 
 			new ItemSalesInfo( typeof(	ArtifactLargeVase	),	5000	,	1	,	95	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Art	),
 			new ItemSalesInfo( typeof(	ArtifactVase	),	5000	,	1	,	95	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Art	),

--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -12,6 +12,7 @@ using Server.Spells.Necromancy;
 using Server.Spells;
 using Server.Spells.Ninjitsu;
 using Server.Misc;
+using Server.Systems;
 
 namespace Server.SkillHandlers
 {
@@ -412,6 +413,12 @@ namespace Server.SkillHandlers
 					from.AddToBackpack( stolen );
 
 					StolenItem.Add( stolen, m_Thief, root as Mobile );
+					//contraband boxes can only be found if the thief suceeded at stealing something
+					Mobile m = target as Mobile;
+					if (m != null)
+					{
+					    ContrabandSystem.TryGiveContraband(from, m);
+					}
 				}
 
 				if ( caught )


### PR DESCRIPTION


This adds the contraband system to the game.

When a player succeeds at stealing something, there's a chance based on stealing skill and luck to get a contraband box.

These boxes can be handed to the guildmaster of the thieves guild (by guild members) in exchange for rewards.

A random sentence is generated by each, depending on box rarity:
![436299267-d0b4d07d-b49f-425e-9a78-7ecf7582e904](https://github.com/user-attachments/assets/cd57fcb3-5bf6-4cb2-9e2a-653f0253e9ca)


upon handing in the box, the player receives a reward bag that scales with the box rarity:
![436299382-37cd0479-bb78-4a4e-a43c-2e22097eea1d](https://github.com/user-attachments/assets/96446fd4-d72a-46b1-b92f-b4835c8db4a1)
There's a one hour cooldown between rewards:
![436298984-2e23b807-5fc7-49ec-a076-a72815cc12e5](https://github.com/user-attachments/assets/8acdd4cc-ce97-4cba-b126-2838c9a89ec4)
The boxes are somewhat rare, and their dropchance is influenced by the fame of the monster being stolen. Only the strongest monsters have a chance of awarding the best boxes, and even then those are very rare, as shown here:

![436299642-999d2053-0d67-40ae-87be-386c4c2c70c8](https://github.com/user-attachments/assets/e26cef25-fa6f-4efe-b89d-af049812153a)

The goal of this change is to provide thieves with incentives for actively using their stealing skill while adventuring.
