### PR TITLE
removes taming/herding gains/messages from summons/henchmen

### DIFF
--- a/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperHerdingGain.cs
@@ -31,8 +31,39 @@ namespace Server.Custom.KoperPets
 
         public static void TryGainHerdingSkill(Mobile owner)
         {
-            if (owner == null || !owner.Alive || !MyServerSettings.KoperPets())
-                return; // No skill gain for dead players/system disabled
+
+            bool hasNonSummoned = false;
+            bool hasNonHumanBody = false;
+
+            if (owner.Map != null)
+            {
+            	IPooledEnumerable eable = owner.Map.GetMobilesInRange(owner.Location, 5);
+
+            	foreach (Mobile m in eable)
+            	{
+            		if (m is BaseCreature)
+            		{
+            			BaseCreature pet = (BaseCreature)m;
+                        // we need to check if the player has followers that are not summons or henchman before applying the rest of the function
+            			if (pet.Controlled && pet.ControlMaster == owner)
+            			{
+            				if (!pet.Summoned)
+            					hasNonSummoned = true;
+
+            				if (!pet.Body.IsHuman)
+            					hasNonHumanBody = true;
+
+            				if (hasNonSummoned && hasNonHumanBody)
+            					break;
+            			}
+            		}
+            	}
+            	eable.Free();
+            }
+
+
+            if (owner == null || !owner.Alive || !MyServerSettings.KoperPets() || !hasNonSummoned || !hasNonHumanBody)
+                return; // No skill gain for dead players/system disabled// or players that have only summons or henchman
 
             // Check if the player is on cooldown
             if (_cooldowns.ContainsKey(owner) && DateTime.UtcNow < _cooldowns[owner])

--- a/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
+++ b/Data/Scripts/Custom/KoperPets/KoperTamingGain.cs
@@ -84,7 +84,8 @@ namespace Server.Custom.KoperPets
 
         public static void TryTamingGain(BaseCreature pet, Mobile target)
         {
-            if (pet == null || target == null || !MyServerSettings.KoperPets())
+            // only apply gains to pets that are not summoned and not henchman
+            if (pet == null || target == null || !MyServerSettings.KoperPets() || pet.Summoned || pet.Body.IsHuman)
                 return;
 
             PlayerMobile owner = pet.ControlMaster as PlayerMobile;


### PR DESCRIPTION
The intention of the system is to give progression to tamers, so it makes little sense that giving commands to a hired henchman will give you taming/herding gains. 

This change adds a couple checks to prevent the messages/gains from triggering. 