### PR TITLE
allows for containers to be targetted by id'ing skills.

### DIFF
--- a/Data/Scripts/System/Skills/ArmsLore.cs
+++ b/Data/Scripts/System/Skills/ArmsLore.cs
@@ -34,13 +34,26 @@ namespace Server.SkillHandlers
 				AllowNonlocal = true;
 			}
 
-			protected override void OnTarget( Mobile from, object targeted )
+			protected override void OnTarget(Mobile from, object targeted)
 			{
-				if ( targeted is Item )
-				{
-					Item examine = (Item)targeted;
-					RelicFunctions.IDItem( from, from, examine, SkillName.ArmsLore );
-				}
+			   if (targeted is Item)
+			   {
+			       Item examine = (Item)targeted;
+			       int identified = RelicIDHelper.TryRecursiveIdentify(from, examine, IDSkill.ArmsLore, SkillName.ArmsLore);
+
+			       if (examine is Container)
+			       {
+			           if (identified == 0)
+			               from.SendMessage("There is nothing in this container that requires Arms Lore to identify.");
+			           else
+			               from.SendMessage("You inspect the contents of the container using your Arms Lore skill.");
+			       }
+			       else
+			       {
+			           if (identified == 0)
+			               from.SendMessage("That item cannot be identified with Arms Lore.");
+			       }
+			   }
 			}
 		}
 	}

--- a/Data/Scripts/System/Skills/Mercantile.cs
+++ b/Data/Scripts/System/Skills/Mercantile.cs
@@ -33,13 +33,26 @@ namespace Server.Items
 				AllowNonlocal = true;
 			}
 
-			protected override void OnTarget( Mobile from, object targeted )
+			protected override void OnTarget(Mobile from, object targeted)
 			{
-				if ( targeted is Item )
-				{
-					Item examine = (Item)targeted;
-					RelicFunctions.IDItem( from, from, examine, SkillName.Mercantile );
-				}
+			    if (targeted is Item)
+			    {
+			        Item examine = (Item)targeted;
+			        int identified = RelicIDHelper.TryRecursiveIdentify(from, examine, IDSkill.Mercantile, SkillName.Mercantile);
+
+			        if (examine is Container)
+			        {
+			            if (identified == 0)
+			                from.SendMessage("There is nothing in this container that requires Mercantile to identify.");
+			            else
+			                from.SendMessage("You examine the goods using your Mercantile knowledge.");
+			        }
+			        else
+			        {
+			            if (identified == 0)
+			                from.SendMessage("That item cannot be identified with Mercantile.");
+			        }
+			    }
 			}
 		}
 	}

--- a/Data/Scripts/System/Skills/Tasting.cs
+++ b/Data/Scripts/System/Skills/Tasting.cs
@@ -109,7 +109,20 @@ namespace Server.Items
 				else if ( targeted is Item )
 				{
 					Item examine = (Item)targeted;
-					RelicFunctions.IDItem( from, from, examine, SkillName.Tasting );
+					int identified = RelicIDHelper.TryRecursiveIdentify(from, examine, IDSkill.Tasting, SkillName.Tasting);
+
+       				if (examine is Container)
+       				{
+       				    if (identified == 0)
+       				        from.SendMessage("There is nothing in this container that requires Tasting to identify.");
+       				    else
+       				        from.SendMessage("You sample and inspect the items using your Tasting skill.");
+       				}
+       				else
+       				{
+       				    if (identified == 0)
+       				        from.SendMessage("That item cannot be identified with Tasting.");
+       				}
 				}
 			}
 		}


### PR DESCRIPTION
This change makes it so that when a player uses arms lore / mercantile / tasting on a container in their inventory, the game will attempt to identify every item inside the container. It also recursively targets items inside nested containers. 