### PR TITLE
double the gold value for calculating tithing points for death knight and priest, reduces the cost of their class spells in half

### DIFF
--- a/Data/Scripts/Magic/Death Knight/DeathKnightSpellBookGump.cs
+++ b/Data/Scripts/Magic/Death Knight/DeathKnightSpellBookGump.cs
@@ -165,7 +165,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "the Ancient Pyramid", Map.Sosaria, out placer_1, out xc_1, out yc_1 );
 					name1 = "Banish";
-					soul1 = "56";
+					soul1 = "38";
 					skil1 = "40";
 					mana1 = "36";
 					text1 = ""; if ( !this.HasSpell( from, 750) ){ m_NotHave_1 = true; z1=220; text1 = "Saint Kargoth<BR>Land of Sosaria: Ancient Pyramid<BR>" + sGrave + "<BR><BR>"; }
@@ -174,7 +174,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Clues", Map.Sosaria, out placer_2, out xc_2, out yc_2 );
 					name2 = "Demonic Touch";
-					soul2 = "21";
+					soul2 = "11";
 					skil2 = "15";
 					mana2 = "16";
 					text2 = ""; if ( !this.HasSpell( from, 751) ){ m_NotHave_2 = true; z2=220; text2 = "Lord Monduiz Dephaar<BR>Land of Sosaria: Dungeon Clues<BR>" + sGrave + "<BR><BR>"; }
@@ -185,7 +185,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Doom", Map.Sosaria, out placer_1, out xc_1, out yc_1 );
 					name1 = "Devil Pact";
-					soul1 = "98";
+					soul1 = "49";
 					skil1 = "90";
 					mana1 = "60";
 					text1 = ""; if ( !this.HasSpell( from, 752) ){ m_NotHave_1 = true; z1=220; text1 = "Lady Kath of Naelex<BR>Land of Sosaria: Dungeon Doom<BR>" + sGrave + "<BR><BR>"; }
@@ -194,7 +194,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "the Fires of Hell", Map.Sosaria, out placer_2, out xc_2, out yc_2 );
 					name2 = "Grim Reaper";
-					soul2 = "42";
+					soul2 = "21";
 					skil2 = "30";
 					mana2 = "28";
 					text2 = ""; if ( !this.HasSpell( from, 753) ){ m_NotHave_2 = true; z2=220; text2 = "Prince Myrhal of Rax<BR>Land of Sosaria: Fires of Hell<BR>" + sGrave + "<BR><BR>"; }
@@ -205,7 +205,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Exodus", Map.Sosaria, out placer_1, out xc_1, out yc_1 );
 					name1 = "Hag Hand";
-					soul1 = "7";
+					soul1 = "3";
 					skil1 = "5";
 					mana1 = "8";
 					text1 = ""; if ( !this.HasSpell( from, 754) ){ m_NotHave_1 = true; z1=220; text1 = "Sir Maeril of Naelax<BR>Land of Sosaria: Dungeon Exodus<BR>" + sGrave + "<BR><BR>"; }
@@ -214,7 +214,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "the City of the Dead", Map.Sosaria, out placer_2, out xc_2, out yc_2 );
 					name2 = "Hellfire";
-					soul2 = "84";
+					soul2 = "42";
 					skil2 = "70";
 					mana2 = "52";
 					text2 = ""; if ( !this.HasSpell( from, 755) ){ m_NotHave_2 = true; z2=220; text2 = "Sir Farian of Lirtham<BR>Land of Ambrosia: City of the Dead<BR>" + sGrave + "<BR><BR>"; }
@@ -225,7 +225,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "the Mausoleum", Map.Sosaria, out placer_1, out xc_1, out yc_1 );
 					name1 = "Lucifer's Bolt";
-					soul1 = "35";
+					soul1 = "18";
 					skil1 = "25";
 					mana1 = "24";
 					text1 = ""; if ( !this.HasSpell( from, 756) ){ m_NotHave_1 = true; z1=220; text1 = "Lord Androma of Gara<BR>Island of Umber Veil: the Mausoleum<BR>" + sGrave + "<BR><BR>"; }
@@ -234,7 +234,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Despise", Map.Lodor, out placer_2, out xc_2, out yc_2 );
 					name2 = "Orb of Orcus";
-					soul2 = "200";
+					soul2 = "100";
 					skil2 = "80";
 					mana2 = "56";
 					text2 = ""; if ( !this.HasSpell( from, 757) ){ m_NotHave_2 = true; z2=220; text2 = "Sir Oslan Knarren<BR>Land of Lodoria: Dungeon Despise<BR>" + sGrave + "<BR><BR>"; }
@@ -245,7 +245,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Deceit", Map.Lodor, out placer_1, out xc_1, out yc_1 );
 					name1 = "Shield of Hate";
-					soul1 = "77";
+					soul1 = "38";
 					skil1 = "60";
 					mana1 = "48";
 					text1 = ""; if ( !this.HasSpell( from, 758) ){ m_NotHave_1 = true; z1=220; text1 = "Sir Rezinar of Haxx<BR>Land of Lodoria: Dungeon Deceit<BR>" + sGrave + "<BR><BR>"; }
@@ -254,7 +254,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Wrong", Map.Lodor, out placer_2, out xc_2, out yc_2 );
 					name2 = "Soul Reaper";
-					soul2 = "63";
+					soul2 = "33";
 					skil2 = "45";
 					mana2 = "40";
 					text2 = ""; if ( !this.HasSpell( from, 759) ){ m_NotHave_2 = true; z2=220; text2 = "Lord Thyrian of Naelax<BR>Land of Lodoria: Dungeon Wrong<BR>" + sGrave + "<BR><BR>"; }
@@ -265,7 +265,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "the Lodoria Catacombs", Map.Lodor, out placer_1, out xc_1, out yc_1 );
 					name1 = "Strength of Steel";
-					soul1 = "28";
+					soul1 = "14";
 					skil1 = "20";
 					mana1 = "20";
 					text1 = ""; if ( !this.HasSpell( from, 760) ){ m_NotHave_1 = true; z1=220; text1 = "Sir Minar of Darmen<BR>Land of Lodoria: Lodoria Catacombs<BR>" + sGrave + "<BR><BR>"; }
@@ -274,7 +274,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Shame", Map.Lodor, out placer_2, out xc_2, out yc_2 );
 					name2 = "Strike";
-					soul2 = "14";
+					soul2 = "7";
 					skil2 = "10";
 					mana2 = "12";
 					text2 = ""; if ( !this.HasSpell( from, 761) ){ m_NotHave_2 = true; z2=220; text2 = "Duke Urkar of Torquann<BR>Land of Lodoria: Dungeon Shame<BR>" + sGrave + "<BR><BR>"; }
@@ -285,7 +285,7 @@ namespace Server.Gumps
 				{
 					sGrave = Worlds.GetAreaEntrance( 0, "the City of Embers", Map.Lodor, out placer_1, out xc_1, out yc_1 );
 					name1 = "Succubus Skin";
-					soul1 = "49";
+					soul1 = "25";
 					skil1 = "35";
 					mana1 = "32";
 					text1 = ""; if ( !this.HasSpell( from, 762) ){ m_NotHave_1 = true; z1=220; text1 = "Sir Luren the Boar<BR>Land of Lodoria: the City of Embers<BR>" + sGrave + "<BR><BR>"; }
@@ -294,7 +294,7 @@ namespace Server.Gumps
 
 					sGrave = Worlds.GetAreaEntrance( 0, "Dungeon Hythloth", Map.Lodor, out placer_2, out xc_2, out yc_2 );
 					name2 = "Wrath";
-					soul2 = "70";
+					soul2 = "35";
 					skil2 = "50";
 					mana2 = "44";
 					text2 = ""; if ( !this.HasSpell( from, 763) ){ m_NotHave_2 = true; z2=220; text2 = "Lord Khayven of Rax<BR>Land of Lodoria: Dungeon Hythloth<BR>" + sGrave + "<BR><BR>"; }

--- a/Data/Scripts/Magic/Death Knight/Spells/BanishSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/BanishSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 56; } }
+		public override int RequiredTithing{ get{ return 28; } }
 		public override double RequiredSkill{ get{ return 40.0; } }
 		public override int RequiredMana{ get{ return 36; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/DemonicTouchSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/DemonicTouchSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 21; } }
+		public override int RequiredTithing{ get{ return 11; } }
 		public override double RequiredSkill{ get{ return 15.0; } }
 		public override int RequiredMana{ get{ return 16; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/DevilPactSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/DevilPactSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 98; } }
+		public override int RequiredTithing{ get{ return 49; } }
 		public override double RequiredSkill{ get{ return 90.0; } }
 		public override int RequiredMana{ get{ return 60; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/GrimReaperSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/GrimReaperSpell.cs
@@ -18,7 +18,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 0.5 ); } }
-		public override int RequiredTithing{ get{ return 42; } }
+		public override int RequiredTithing{ get{ return 21; } }
 		public override double RequiredSkill{ get{ return 30.0; } }
 		public override bool BlocksMovement{ get{ return false; } }
 		public override int RequiredMana{ get{ return 28; } }

--- a/Data/Scripts/Magic/Death Knight/Spells/HagHandSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/HagHandSpell.cs
@@ -23,7 +23,7 @@ namespace Server.Spells.DeathKnight
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
 		public override double RequiredSkill{ get{ return 5.0; } }
 		public override int RequiredMana{ get{ return 8; } }
-		public override int RequiredTithing{ get{ return 7; } }
+		public override int RequiredTithing{ get{ return 3; } }
 
 		public HagHandSpell( Mobile caster, Item scroll ) : base( caster, scroll, m_Info )
 		{

--- a/Data/Scripts/Magic/Death Knight/Spells/HellfireSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/HellfireSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 84; } }
+		public override int RequiredTithing{ get{ return 42; } }
 		public override double RequiredSkill{ get{ return 70.0; } }
 		public override int RequiredMana{ get{ return 52; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/LucifersBoltSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/LucifersBoltSpell.cs
@@ -13,7 +13,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 35; } }
+		public override int RequiredTithing{ get{ return 18; } }
 		public override double RequiredSkill{ get{ return 25.0; } }
 		public override int RequiredMana{ get{ return 24; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/OrbOfOrcusSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/OrbOfOrcusSpell.cs
@@ -19,7 +19,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 200; } }
+		public override int RequiredTithing{ get{ return 100; } }
 		public override double RequiredSkill{ get{ return 80.0; } }
 		public override int RequiredMana{ get{ return 56; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/ShieldOfHateSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/ShieldOfHateSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 77; } }
+		public override int RequiredTithing{ get{ return 38; } }
 		public override double RequiredSkill{ get{ return 60.0; } }
 		public override int RequiredMana{ get{ return 48; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/SoulReaperSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/SoulReaperSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 63; } }
+		public override int RequiredTithing{ get{ return 33; } }
 		public override double RequiredSkill{ get{ return 45.0; } }
 		public override int RequiredMana{ get{ return 40; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/StrengthOfSteelSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/StrengthOfSteelSpell.cs
@@ -13,7 +13,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 28; } }
+		public override int RequiredTithing{ get{ return 14; } }
 		public override double RequiredSkill{ get{ return 20.0; } }
 		public override int RequiredMana{ get{ return 20; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/StrikeSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/StrikeSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 14; } }
+		public override int RequiredTithing{ get{ return 7; } }
 		public override double RequiredSkill{ get{ return 10.0; } }
 		public override int RequiredMana{ get{ return 12; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/SuccubusSkinSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/SuccubusSkinSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.DeathKnight
 
 		private static Hashtable m_Table = new Hashtable();
         public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds(3); } }
-		public override int RequiredTithing{ get{ return 49; } }
+		public override int RequiredTithing{ get{ return 25; } }
         public override int RequiredMana { get { return 32; } }
 		public override double RequiredSkill{ get{ return 35.0; } }
 

--- a/Data/Scripts/Magic/Death Knight/Spells/WrathSpell.cs
+++ b/Data/Scripts/Magic/Death Knight/Spells/WrathSpell.cs
@@ -18,7 +18,7 @@ namespace Server.Spells.DeathKnight
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 1 ); } }
-		public override int RequiredTithing{ get{ return 70; } }
+		public override int RequiredTithing{ get{ return 35; } }
 		public override double RequiredSkill{ get{ return 50.0; } }
 		public override int RequiredMana{ get{ return 44; } }
 

--- a/Data/Scripts/Magic/Holy Man/HolyManSpellBookGump.cs
+++ b/Data/Scripts/Magic/Holy Man/HolyManSpellBookGump.cs
@@ -165,7 +165,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the Village of Springvale", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Banish";
-					pity1 = "120";
+					pity1 = "60";
 					skil1 = "60";
 					mana1 = "30";
 					text1 = ""; if ( !this.HasSpell( from, 770) ){ m_NotHave_1 = true; z1=220; text1 = "Patriarch Morden rests south of the Village of Springvale<br>" + grav1 + "<br><br>Mantra: exilium<BR><BR>"; }
@@ -174,7 +174,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the Village of Whisper", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Dampen Spirit";
-					pity2 = "140";
+					pity2 = "70";
 					skil2 = "70";
 					mana2 = "35";
 					text2 = ""; if ( !this.HasSpell( from, 771) ){ m_NotHave_2 = true; z2=220; text2 = "Archbishop Halyrn rests by the Village of Whisper<br>" + grav2 + "<br><br>Mantra: accipe spiritum<BR><BR>"; }
@@ -185,7 +185,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the City of Kuldara", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Enchant";
-					pity1 = "180";
+					pity1 = "90";
 					skil1 = "90";
 					mana1 = "45";
 					text1 = ""; if ( !this.HasSpell( from, 772) ){ m_NotHave_1 = true; z1=220; text1 = "Bishop Leantre rests in the Kuldar Cemetery<br>" + grav1 + "<br><br>Mantra: fascinare<BR><BR>"; }
@@ -194,7 +194,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the City of Elidor", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Hammer of Faith";
-					pity2 = "100";
+					pity2 = "50";
 					skil2 = "50";
 					mana2 = "25";
 					text2 = ""; if ( !this.HasSpell( from, 773) ){ m_NotHave_2 = true; z2=220; text2 = "Deacon Wilems rests in the City of Elidor<br>" + grav2 + "<br><br>Mantra: malleo fidei<BR><BR>"; }
@@ -205,7 +205,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the City of Britain", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Heavenly Light";
-					pity1 = "20";
+					pity1 = "10";
 					skil1 = "10";
 					mana1 = "5";
 					text1 = ""; if ( !this.HasSpell( from, 774) ){ m_NotHave_1 = true; z1=220; text1 = "Drumat the Apostle rests by the City of Britain<br>" + grav1 + "<br><br>Mantra: caelesti lumine<BR><BR>"; }
@@ -214,7 +214,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the Town of Moon", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Nourish";
-					pity2 = "20";
+					pity2 = "10";
 					skil2 = "10";
 					mana2 = "5";
 					text2 = ""; if ( !this.HasSpell( from, 775) ){ m_NotHave_2 = true; z2=220; text2 = "Vincent the Priest rests by the Town of Moon<br>" + grav2 + "<br><br>Mantra: famem prohibere<BR><BR>"; }
@@ -225,7 +225,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the Town of Renika", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Purge";
-					pity1 = "80";
+					pity1 = "40";
 					skil1 = "40";
 					mana1 = "20";
 					text1 = ""; if ( !this.HasSpell( from, 776) ){ m_NotHave_1 = true; z1=220; text1 = "Abigayl the Preacher rests near the Church of the Divine in the Town of Renika<br>" + grav1 + "<br><br>Mantra: deiectionem<BR><BR>"; }
@@ -234,7 +234,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "Greensky Village", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Rebirth";
-					pity2 = "400";
+					pity2 = "200";
 					skil2 = "80";
 					mana2 = "40";
 					text2 = ""; if ( !this.HasSpell( from, 777) ){ m_NotHave_2 = true; z2=220; text2 = "Cardinal Greggs rests near the Greensky Village<br>" + grav2 + "<br><br>Mantra: reditus vitae<BR><BR>"; }
@@ -245,7 +245,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the Village of Grey", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Sacred Boon";
-					pity1 = "40";
+					pity1 = "20";
 					skil1 = "20";
 					mana1 = "10";
 					text1 = ""; if ( !this.HasSpell( from, 778) ){ m_NotHave_1 = true; z1=220; text1 = "Father Michal rests by the Village of Grey<br>" + grav1 + "<br><br>Mantra: sacrum munus<BR><BR>"; }
@@ -254,7 +254,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the City of Montor", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Sanctify";
-					pity2 = "60";
+					pity2 = "30";
 					skil2 = "30";
 					mana2 = "15";
 					text2 = ""; if ( !this.HasSpell( from, 779) ){ m_NotHave_2 = true; z2=220; text2 = "Sister Tiana rests south of the City of Montor<br>" + grav2 + "<br><br>Mantra: benedicite<BR><BR>"; }
@@ -265,7 +265,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the Village of Islegem", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Seance";
-					pity1 = "120";
+					pity1 = "60";
 					skil1 = "60";
 					mana1 = "30";
 					text1 = ""; if ( !this.HasSpell( from, 780) ){ m_NotHave_1 = true; z1=220; text1 = "Brother Kurklan rests near the Village of Islegem<br>" + grav1 + "<br><br>Mantra: spiritus mundi<BR><BR>"; }
@@ -274,7 +274,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the City of Lodoria", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Smite";
-					pity2 = "80";
+					pity2 = "40";
 					skil2 = "40";
 					mana2 = "20";
 					text2 = ""; if ( !this.HasSpell( from, 781) ){ m_NotHave_2 = true; z2=220; text2 = "Edwin the Pope rests in the Lodoria Cemetery<br>" + grav2 + "<br><br>Mantra: percutiat<BR><BR>"; }
@@ -285,7 +285,7 @@ namespace Server.Gumps
 				{
 					grav1 = Worlds.GetTown( 0, "the Town of Devil Guard", Map.Internal, out placer_1, out xc_1, out yc_1 );
 					name1 = "Touch of Life";
-					pity1 = "40";
+					pity1 = "20";
 					skil1 = "20";
 					mana1 = "10";
 					text1 = ""; if ( !this.HasSpell( from, 782) ){ m_NotHave_1 = true; z1=220; text1 = "Xephyn the Monk rests near the Town of Devil Guard<br>" + grav1 + "<br><br>Mantra: tactus vitae<BR><BR>"; }
@@ -294,7 +294,7 @@ namespace Server.Gumps
 
 					grav2 = Worlds.GetTown( 0, "the Village of Fawn", Map.Internal, out placer_2, out xc_2, out yc_2 );
 					name2 = "Trial by Fire";
-					pity2 = "500";
+					pity2 = "250";
 					skil2 = "30";
 					mana2 = "15";
 					text2 = ""; if ( !this.HasSpell( from, 783) ){ m_NotHave_2 = true; z2=220; text2 = "Chancellor Davis rests on an island near the Village of Fawn<br>" + grav2 + "<br><br>Mantra: igne iudicii<BR><BR>"; }

--- a/Data/Scripts/Magic/Holy Man/Spells/BanishEvilSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/BanishEvilSpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 120; } }
+		public override int RequiredTithing{ get{ return 60; } }
 		public override double RequiredSkill{ get{ return 60.0; } }
 		public override int RequiredMana{ get{ return 30; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/DampenSpiritSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/DampenSpiritSpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 140; } }
+		public override int RequiredTithing{ get{ return 35; } }
 		public override double RequiredSkill{ get{ return 70.0; } }
 		public override int RequiredMana{ get{ return 35; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/EnchantSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/EnchantSpell.cs
@@ -20,7 +20,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 180; } }
+		public override int RequiredTithing{ get{ return 90; } }
 		public override double RequiredSkill{ get{ return 90.0; } }
 		public override int RequiredMana{ get{ return 45; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/HammerOfFaithSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/HammerOfFaithSpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 100; } }
+		public override int RequiredTithing{ get{ return 50; } }
 		public override double RequiredSkill{ get{ return 50.0; } }
 		public override int RequiredMana{ get{ return 25; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/HeavenlyLightSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/HeavenlyLightSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 20; } }
+		public override int RequiredTithing{ get{ return 10; } }
 		public override double RequiredSkill{ get{ return 10.0; } }
 		public override int RequiredMana{ get{ return 5; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/NourishSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/NourishSpell.cs
@@ -15,7 +15,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 20; } }
+		public override int RequiredTithing{ get{ return 10; } }
 		public override double RequiredSkill{ get{ return 10.0; } }
 		public override int RequiredMana{ get{ return 5; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/PurgeSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/PurgeSpell.cs
@@ -20,7 +20,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 80; } }
+		public override int RequiredTithing{ get{ return 40; } }
 		public override double RequiredSkill{ get{ return 40.0; } }
 		public override int RequiredMana{ get{ return 20; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/RebirthSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/RebirthSpell.cs
@@ -18,7 +18,7 @@ namespace Server.Spells.HolyMan
             );
  
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 400; } }
+		public override int RequiredTithing{ get{ return 200; } }
 		public override double RequiredSkill{ get{ return 80.0; } }
 		public override int RequiredMana{ get{ return 40; } }
  

--- a/Data/Scripts/Magic/Holy Man/Spells/SacredBoonSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/SacredBoonSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 40; } }
+		public override int RequiredTithing{ get{ return 20; } }
 		public override double RequiredSkill{ get{ return 20.0; } }
 		public override int RequiredMana{ get{ return 10; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/SanctifySpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/SanctifySpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 60; } }
+		public override int RequiredTithing{ get{ return 30; } }
 		public override double RequiredSkill{ get{ return 30.0; } }
 		public override int RequiredMana{ get{ return 15; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/SeanceSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/SeanceSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 120; } }
+		public override int RequiredTithing{ get{ return 60; } }
 		public override double RequiredSkill{ get{ return 60.0; } }
 		public override int RequiredMana{ get{ return 30; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/SmiteSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/SmiteSpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 80; } }
+		public override int RequiredTithing{ get{ return 40; } }
 		public override double RequiredSkill{ get{ return 40.0; } }
 		public override int RequiredMana{ get{ return 20; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/TouchOfLifeSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/TouchOfLifeSpell.cs
@@ -16,7 +16,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 40; } }
+		public override int RequiredTithing{ get{ return 20; } }
 		public override double RequiredSkill{ get{ return 20.0; } }
 		public override int RequiredMana{ get{ return 10; } }
 

--- a/Data/Scripts/Magic/Holy Man/Spells/TrialByFireSpell.cs
+++ b/Data/Scripts/Magic/Holy Man/Spells/TrialByFireSpell.cs
@@ -17,7 +17,7 @@ namespace Server.Spells.HolyMan
 			);
 
 		public override TimeSpan CastDelayBase { get { return TimeSpan.FromSeconds( 3 ); } }
-		public override int RequiredTithing{ get{ return 500; } }
+		public override int RequiredTithing{ get{ return 250; } }
 		public override double RequiredSkill{ get{ return 30.0; } }
 		public override int RequiredMana{ get{ return 15; } }
 

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -8025,7 +8025,7 @@ namespace Server.Mobiles
 					if ( lantern is SoulLantern )
 					{
 						SoulLantern souls = (SoulLantern)lantern;
-						souls.TrappedSouls = souls.TrappedSouls + this.TotalGold;
+						souls.TrappedSouls = souls.TrappedSouls + (this.TotalGold*2);
 						if ( souls.TrappedSouls > 100000 ){ souls.TrappedSouls = 100000; }
 						souls.InvalidateProperties();
 
@@ -8060,7 +8060,8 @@ namespace Server.Mobiles
 					if ( symbol is HolySymbol )
 					{
 						HolySymbol banish = (HolySymbol)symbol;
-						banish.BanishedEvil = banish.BanishedEvil + this.TotalGold;
+						// doubles the base gold calculation for more priest points
+						banish.BanishedEvil = (banish.BanishedEvil + (this.TotalGold)*2);
 						if ( banish.BanishedEvil > 100000 ){ banish.BanishedEvil = 100000; }
 						banish.InvalidateProperties();
 


### PR DESCRIPTION
Given the effort it takes to unlock both the priest and the death knight, it was disappointing to figure out their resource system. It was costly for what you got in return for going through the trouble of unlocking them. 

This changes flat out cuts tithing costs of all of their spells in half, and increases the amount of points generated by wearing the lantern / holy symbol. 