### PR TITLE
makes animate dead more useful for powerful necromancers

### DIFF
--- a/Data/Scripts/Magic/Necromancy/AnimateDeadSpell.cs
+++ b/Data/Scripts/Magic/Necromancy/AnimateDeadSpell.cs
@@ -106,8 +106,7 @@ namespace Server.Spells.Necromancy
 						else if ( bc.PoisonImmune == Poison.Lethal ){ immune = 5; }
 
 						// THIS MODIFIES THE MONSTER BASED ON THE LEVEL OF THE CORPSE AND THE SKILLS OF THE CASTER
-						// TO GET A ANIMATED CREATURE WITH FULL STATS, A CASTER NEEDS A 125 IN BOTH SKILLS
-						int modify = level_caster - ( level_corpse + 50 );
+						int modify = level_caster - ( level_corpse );
 						double mod = 1.0;
 						if ( modify < 0 )
 						{


### PR DESCRIPTION
The check used before was exceedingly punishing and made most desirable animation targets scale down dramatically.  
level_caster caps at 100. 
level_corpse can go into the mid 80s for some creatures. Many of them go past 50.

Results of animating a primeval dragon at 125 spirit speak and 125 necromancy (which shouldn't reduce stats at all, but does):
![Sem título](https://github.com/user-attachments/assets/f96c488f-7f2a-4d13-b9a3-2fc0245f75cc)

After the change:
![Sem título-1](https://github.com/user-attachments/assets/7ab80c96-c7cf-4ac4-843e-5107b64c5aed)

As a 4-slot follower that the necromancer had to kill in the first place to cast the spell, it makes sense for it to be something that can take two hits in a dungeon.