### PR TITLE
adds [organizepotions and adds a "setup" and "organize" context menu to alchemist's belt pouch

### DIFF
--- a/Data/Scripts/System/Commands/Player/OrganizePotions.cs
+++ b/Data/Scripts/System/Commands/Player/OrganizePotions.cs
@@ -1,0 +1,33 @@
+using System;
+using Server;
+using Server.Mobiles;
+using Server.Items;
+using System.Collections.Generic;
+using Server.Commands;
+
+namespace Server.Scripts.Commands
+{
+    public class OrganizePotions
+    {
+        public static void Initialize()
+        {
+            CommandSystem.Register( "OrganizePotions", AccessLevel.Player, new CommandEventHandler( OrganizePotions_OnCommand ) );
+        }
+
+        public static void OrganizePotions_OnCommand( CommandEventArgs e )
+        {
+            Mobile m = e.Mobile;
+            Item pouch = m.Backpack.FindItemByType( typeof( AlchemistPouch ) );
+
+            if ( pouch != null )
+            {
+                AlchemistPouch ap = pouch as AlchemistPouch;
+                ap.OrganizePotions( m );
+            }
+            else
+            {
+                m.SendMessage( "You need an alchemist's belt pouch in your backpack to organize your potions!" );
+            }
+        }
+    }
+}


### PR DESCRIPTION
[organizepotions just moves any valid potion from isAlchemy() to an alchemist's belt pouch

the "Organize" context menu has been switched to "Setup" and now the new "Organize" menu item moves all valid potions to the alchemist's belt pouch

more potions have been added to isAlchemy()