### PR TITLE
Close InnRoom chest immediately upon moving a single step

### DIFF
--- a/Data/System/Source/Mobile.cs
+++ b/Data/System/Source/Mobile.cs
@@ -3142,19 +3142,9 @@ namespace Server
 
 			if ( m_InnOpen )
 			{
-				bool leaveOpen = false;
-
-				foreach ( Item i in this.GetItemsInRange( 3 ) )
-				{
-					if ( i is InnRoom && ((InnRoom)i).Owner == this )
-						leaveOpen = true;
-				}
-				if ( !leaveOpen )
-				{
-					InnOpen = false;
-					m_InnRoom.ItemID = 0x4CF0;
-					this.BankBox.DropItem( m_InnRoom );
-				}
+				InnOpen = false;
+				m_InnRoom.ItemID = 0x4CF0;
+				this.BankBox.DropItem( m_InnRoom );
 			}
 
 			if( (m_Direction & Direction.Mask) == (d & Direction.Mask) )


### PR DESCRIPTION
The InnRoom chest is a hidden container in the player's bank box that is moved to their feet and opened. As with other regular containers, moving while the container is open does not close them until the player gets out of range.

However, as most players treat the InnRoom chest as an extension of their bank, this behavior is not necessary and can often lead to losing the chest. This is due to the fact they can enter the inn, open their chest while near the exit door, then leave without taking enough steps away to "close" and return the chest to their bank (thus leaving it behind and causing it to decay).

This PR changes the InnRoom chest so that it closes immediately when the player moves a single step, much like how the bank box works, to prevent these instances of loss. Fixes #238 and requires a `World.exe` build.