### PR TITLE
prevent afk farming exploit and adds timer to contraband boxes

### DIFF
--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -411,8 +411,10 @@ namespace Server.SkillHandlers
 					StolenItem.Add( stolen, m_Thief, root as Mobile );
 					//contraband boxes can only be found if the thief suceeded at stealing something
 					Mobile m = target as Mobile;
-					if (m != null)
+					if (m != null && !m.Player)
 					{
+						BaseCreature creature = m as BaseCreature;
+						if(creature == null || (!creature.Controlled && !creature.Summoned))
 					    ContrabandSystem.TryGiveContraband(from, m);
 					}
 				}


### PR DESCRIPTION
- contraband boxes now have an one hour cooldown between drops.
- prevents boxes from being generated when stealing from a player, tamed pet or summoned creature. 