### PR TITLE
replaces the stealing system to only award gold instead of item clutter

### DIFF
--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -18,9 +18,10 @@ namespace Server.SkillHandlers
 {
 	public class Stealing
 	{
+		private static Dictionary<Mobile, DateTime> _lastStealTime = new Dictionary<Mobile, DateTime>();
 		public static void Initialize()
 		{
-			SkillInfo.Table[33].Callback = new SkillUseCallback( OnUse );
+			SkillInfo.Table[33].Callback = new SkillUseCallback(OnUse);
 		}
 
 		public static readonly bool ClassicMode = false;
@@ -387,17 +388,78 @@ namespace Server.SkillHandlers
 					root = ((Item)target).RootParent;
 					stolen = TryStealItem( (Item)target, ref caught );
 				} 
+				
 				else if ( target is Mobile )
 				{
-					Container pack = ((Mobile)target).Backpack;
+				    Mobile victim = (Mobile)target;
+				    Container pack = victim.Backpack;				
 
-					if ( pack != null && pack.Items.Count > 0 )
-					{
-						int randomIndex = Utility.Random( pack.Items.Count );
+				    BaseCreature bc = victim as BaseCreature;
+				    bool isCreature = (bc != null);
+				    bool isValidNpc = isCreature && !bc.Controlled && !bc.Summoned;				
 
-						root = target;
-						stolen = TryStealItem( pack.Items[randomIndex], ref caught );
-					}
+				    if (isValidNpc && pack != null && pack.Items.Count > 0)
+				    {
+				        if (_lastStealTime.ContainsKey(from))
+				        {
+							DateTime last = (DateTime)_lastStealTime[from];
+   							DateTime nextAllowedTime = last + TimeSpan.FromMinutes(1);
+   							if (DateTime.UtcNow < nextAllowedTime)
+   							{
+   							    TimeSpan remaining = nextAllowedTime - DateTime.UtcNow;
+   							    int secondsLeft = (int)remaining.TotalSeconds;
+								from.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, string.Format("You must wait {0} seconds before you can attempt to steal again.", secondsLeft));
+   							    from.SendMessage(string.Format("You must wait {0} seconds before you can attempt to steal again.", secondsLeft));
+   							    return;
+   							}
+				        }				
+
+				        _lastStealTime[from] = DateTime.UtcNow;				
+
+				        int fame = victim.Fame;
+				        int gold = 0;				
+
+				        if (fame < 100) gold = Utility.RandomMinMax(2, 5);
+				        else if (fame < 500) gold = Utility.RandomMinMax(2, 12);
+				        else if (fame < 1000) gold = Utility.RandomMinMax(4, 32);
+				        else if (fame < 2500) gold = Utility.RandomMinMax(8, 62);
+				        else if (fame < 5000) gold = Utility.RandomMinMax(16, 102);
+				        else if (fame < 7500) gold = Utility.RandomMinMax(32, 162);
+				        else if (fame < 10000) gold = Utility.RandomMinMax(48, 242);
+				        else if (fame < 14999) gold = Utility.RandomMinMax(80, 362);
+				        else gold = Utility.RandomMinMax(160, 442);				
+
+				        // Success roll
+				        if (from.CheckSkill(SkillName.Stealing, 0, 100))
+				        {
+				            Gold stolenGold = new Gold(gold);
+				            from.AddToBackpack(stolenGold);
+							from.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, string.Format("You successfully stole {0} gold.", gold));
+							from.SendMessage(string.Format("You successfully stole {0} gold.", gold));
+				            Titles.AwardKarma(from, -60, true);
+				            from.PlaySound(0x2E6); // Coin sound				
+
+				            // Contraband check
+				            ContrabandSystem.TryGiveContraband(from, victim);
+				        }
+				        else
+				        {
+							from.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, "You failed to steal anything.");
+							from.SendMessage(string.Format("You failed to steal anything."));
+				            from.RevealingAction();
+				            caught = true;
+				        }				
+
+				        return;
+				    }				
+					// fallback - mostly for pet stealing for macroing
+				    if (pack != null && pack.Items.Count > 0)
+				    {
+				        int randomIndex = Utility.Random(pack.Items.Count);				
+
+				        root = target;
+				        stolen = TryStealItem(pack.Items[randomIndex], ref caught);
+				    }
 				} 
 				else 
 				{


### PR DESCRIPTION
When using the stealing skill, a player can be awarded with any random item on the mobile bag, which often led to frustration due to the range of useless/low value items that exist in the game (and also poorly organized backpacks for the OCD-inclined). 

This change does the following:
- when actively using stealing on a non-summoned, non-tamed mobile, a player will receive a random amount of gold based on the mobiles fame, according to this table:
fame     	gold (min/max)
<100		2,5
<500		2,12
<1000		4,32
<2500		8,62
<5000		16,102
<7500		32,162
<10000		48,242
<14999		80,362
15000>		160,442

So if a player steals from a mobile with 7000 fame, they will get an amount of gold between 32 and 162. If they still with something with 15k fame, they get an amount between 160 and 442 and so on. 