### PR TITLE
rebalances pedestal stealing

### DIFF
--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -306,10 +306,6 @@ namespace Server
 
 		public static bool S_DecoArtySteal = false;
 
-	// If set to true, then characters will not receive artifacts from stealable boxes in dungeons. 
-
-		public static bool S_PedStealThrottle = true;
-
 	// If set to true (default), then a character will get a warning before they are entering Skara Brae. This area is an extensive
 	// quest driven area, that has some quest requirements to be met before they can leave that area.
 


### PR DESCRIPTION
Rebalances pedestal stealables by making them more reliant on player's luck instead of arbitrary server restrictions.

- up to 5% chance of getting an artifact at 2k luck
- up to 6.50% chance of getting an oriental deco at 2k luck
- up to 7.50% chance of getting a relic at 2k luck
- up to 20% chance of getting a rare item at 2k luck
- up to 25% chance of getting a magic item at 2k luck

- gold drastically reduced across the board and now entirely dependent on player's luck. 
Luck     gold min/max
2000>  1250, 6000
1000>  850,3000
500>    450,1500
250>    225,750
249<    99,375
These values are modified by the server GetGoldCuteRate setting. 

The S_PedStealThrottle setting was made redundant and removed.

This also makes it so that pedestal bags no longer drop mountains of copper. Only gold is found within then, and this was changed to reduce the bank downtime for thieves. 
