### PR TITLE
normalyzes paralyze duration to be based on a character's magic resistance

### DIFF
--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -987,8 +987,7 @@ namespace Server.Mobiles
 			{
 				Effects.SendLocationEffect( blast1, target.Map, 0x10D3, 30, 10, 0, 0 );
 				target.PlaySound( 0x62D );
-				double webbed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration : ((double)(this.Fame/200));
-				target.Paralyze( TimeSpan.FromSeconds( webbed ) );
+				target.Paralyze( TimeSpan.FromSeconds( GetParalyzeDuration(target,(double)(this.Fame)) ) );
 			}
 			else if ( form == 7 ) // GIANT STONES AND LOGS ------------------------------------------------------------------------------------------
 			{
@@ -1271,17 +1270,14 @@ namespace Server.Mobiles
 				Effects.SendLocationEffect( blast5, target.Map, 0x3400, 60, 0xB97, 0 );
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 3;
-				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration : ((double)(this.Fame/200));
-				target.Paralyze( TimeSpan.FromSeconds( weed ) );
+				target.Paralyze( TimeSpan.FromSeconds( GetParalyzeDuration(target,(double)(this.Fame)) ) );
 			}
 			else if ( form == 35 ) // SMALL WEED BREATH ---------------------------------------------------------------------------------------------
 			{
 				Effects.SendLocationEffect( blast1, target.Map, 0x3400, 60, 0xB97, 0 );
 				Effects.PlaySound( target.Location, target.Map, 0x64F );
 				BreathDistance = 2;
-
-				double weed = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration: ((double)(this.Fame/200));
-				target.Paralyze( TimeSpan.FromSeconds( weed ) );
+				target.Paralyze( TimeSpan.FromSeconds( GetParalyzeDuration(target,(double)(this.Fame)) ) );
 			}
 			else if ( form == 36 ) // ACID SPLASH ---------------------------------------------------------------------------------------------------
 			{
@@ -1298,8 +1294,7 @@ namespace Server.Mobiles
 				Point3D wrapped = new Point3D( ( target.X ), ( target.Y ), (target.Z+2) );
 				Effects.SendLocationEffect( wrapped, target.Map, 0x23AF, 30, 10, 0, 0 );
 				target.PlaySound( 0x5D2 );
-				double wrap = ((double)(this.Fame/200)) > MySettings.S_paralyzeDuration ? MySettings.S_paralyzeDuration: ((double)(this.Fame/200));
-				target.Paralyze( TimeSpan.FromSeconds( wrap ) );
+				target.Paralyze( TimeSpan.FromSeconds( GetParalyzeDuration(target,(double)(this.Fame)) ) );
 			}
 			else if ( form == 38 ) // SMALL STEAM BREATH --------------------------------------------------------------------------------------------
 			{
@@ -1575,6 +1570,17 @@ namespace Server.Mobiles
 				}
 			}
 		}
+		// mummies, spiders, plants and some breath weapons have normalized paralyze duration based on a players Magic Resistance or their fame, capped at 8 seconds.
+		private double GetParalyzeDuration(Mobile target, double fame)
+		{
+			int resist = (int)(target.Skills.MagicResist.Value);
+			// 2s at 125, 8s at 0 magic resist
+			double resistCappedDuration = 8.0 - (resist * (6.0 / 125.0));
+			double fameDuration = fame / 200.0;
+			// Return the smaller of the two
+			return fameDuration > resistCappedDuration ? resistCappedDuration : fameDuration;
+		}
+
 
 		public virtual int BreathComputeDamage()
 		{

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -487,14 +487,6 @@ namespace Server
 		public static int S_SpawnMin = 45;
 		public static int S_SpawnMax = 60;
 
-
-	// This settings controls the limit in seconds by which you can be paralyzed by a monster. 
-	// The default is 10 seconds. It mainly affects mummies, ants, plants and spiders. Setting it to a
-	// value higher than 10 could mean that the paralyze cooldown is lower than its duration, 
-	// which can lead to frustrating fights as enemies can flee and chain-paralyze a character until they heal 
-	// enough to get back into the fight. 
-		public static double S_paralyzeDuration = 10.0;
-
 	///////////////////////////////////////////////////////////////////////////////////////////////
 	// 008 - MERCHANTS ////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This change makes it that instead of a fixed duration, a character's skill is taken into account when a mummy/spider/ant/weed attempts to paralyze them. 
Minimum paralyze duration is set at 2 seconds, Maximum at 8. 
So there's a difference between a mummy throwing wraps at someone with 0 magic resist and someone with 125. 
It also removes the S_paralyzeDuration setting from the settings file as it is no longer used. 