### PR TITLE
Automate build and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,101 @@
+name: Build and Release
+
+on:
+  push:
+    branches: ["*"]
+    tags: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Framework
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build Windows executable
+        run: |
+          cd "Data/System"
+          C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc /optimize /unsafe /t:exe /out:World.exe /win32icon:Source\icon.ico /d:NEWTIMERS /d:NEWPARENT /recurse:Source\*.cs
+
+      - name: Create Windows package
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path release-windows
+          Get-ChildItem -Path . -Exclude release-windows | Copy-Item -Destination release-windows -Recurse -Force
+          Copy-Item release-windows/Data/System/World.exe -Destination release-windows/
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: world-windows
+          path: release-windows/
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mono-mcs zlib1g-dev
+
+      - name: Build Linux executable
+        run: |
+          cd Data/System
+          mcs -optimize+ -unsafe -t:exe -out:World.exe -win32icon:Source/icon.ico -nowarn:219,414 -d:NEWTIMERS -d:NEWPARENT -d:MONO -recurse:Source/*.cs
+
+      - name: Create Linux package
+        run: |
+          mkdir release-linux
+          cp -r * release-linux/ 2>/dev/null || true
+          cp release-linux/Data/System/World.exe release-linux/
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: world-linux
+          path: release-linux/
+
+  create-release:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: [build-windows, build-linux]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: world-windows
+          path: ./world-windows/
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: world-linux
+          path: ./world-linux/
+
+      - name: Get tag name
+        id: tag_name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create archives
+        run: |
+          cd world-windows && zip -r ../${{ steps.tag_name.outputs.TAG_NAME }}-windows.zip . && cd ..
+          cd world-linux && tar -czf ../${{ steps.tag_name.outputs.TAG_NAME }}-linux.tar.gz . && cd ..
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.tag_name.outputs.TAG_NAME }}-windows.zip
+            ${{ steps.tag_name.outputs.TAG_NAME }}-linux.tar.gz
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Secrets of Sosaria
 
+[![Build and Release](../../actions/workflows/build.yml/badge.svg)](../../actions/workflows/build.yml)
+
 For instructions, see [Manual.pdf](Manual.pdf).
 
 ## Vision Statement


### PR DESCRIPTION
This change makes it so that each push will trigger an automatic build on GitHub's servers. This doesn't cost anything and completes in only a couple of minutes. If the build succeeds, it will then check to see if the push was of a tag. If the push is of a tag, it will additionally produce a new GitHub release with artifacts named after the tag.

This will produce both Windows and Linux builds as well for every release.

A badge has been added to the top of the README to indicate that the build is succeeding as of that revision (or not).