### PR TITLE
adds level-based damage scaling for legendary artifacts

### DIFF
--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/BaseLevelAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/BaseLevelAxe.cs
@@ -30,6 +30,12 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelAxe(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FrenziedWhirlwind; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 37; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelBattleAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelBattleAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ElementalStrike; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 31; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelDoubleAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelDoubleAxe.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.StunningStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 33; } }
 		public override float MlSpeed{ get{ return 3.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelExecutionersAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelExecutionersAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 33; } }
 		public override float MlSpeed{ get{ return 3.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelHatchet.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelHatchet.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 41; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelLargeBattleAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelLargeBattleAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.RidingSwipe; } }
 
 		public override int AosStrengthReq{ get{ return 80; } }
-		public override int AosMinDamage{ get{ return 16; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 29; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelTwoHandedAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelTwoHandedAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DefenseMastery; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 16; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 31; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelWarAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Axes/LevelWarAxe.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 33; } }
 		public override float MlSpeed{ get{ return 3.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/BaseLevelKnife.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/BaseLevelKnife.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelKnife(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelButcherKnife.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelButcherKnife.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MagicProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 5; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 49; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelCleaver.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelCleaver.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapStamStrike; } }
 
 		public override int AosStrengthReq{ get{ return 10; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 46; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelDagger.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelDagger.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ToxicStrike; } }
 
 		public override int AosStrengthReq{ get{ return 10; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 56; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelLargeKnife.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelLargeKnife.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MagicProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 5; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 49; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelSkinningKnife.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Knives/LevelSkinningKnife.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ForceOfNature; } }
 
 		public override int AosStrengthReq{ get{ return 5; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 49; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/LevelHarpoon.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/LevelHarpoon.cs
@@ -28,8 +28,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.InfectiousStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 15 : 16; } }
-		public override int AosMaxDamage{ get{ return Core.ML ? 19 : 18; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(15 * GetDamageScaling()) : (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return Core.ML ? (int)(19 * GetDamageScaling()) : (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 5.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/LevelPugilistMits.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/LevelPugilistMits.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 8; } }
-		public override int AosMaxDamage{ get{ return 10; } }
+		public override int AosMinDamage{ get{ return (int)(8 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(10 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 2; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/LevelStave.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/LevelStave.cs
@@ -56,8 +56,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MagicProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 15 : 16; } }
-		public override int AosMaxDamage{ get{ return Core.ML ? 19 : 18; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(15 * GetDamageScaling()) : (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return Core.ML ? (int)(19 * GetDamageScaling()) : (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 5.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/LevelThrowingGloves.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/LevelThrowingGloves.cs
@@ -88,8 +88,8 @@ namespace Server.Items
 		}
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 23; } }
 		public override float MlSpeed{ get{ return 4.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelAssassinSpike.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelAssassinSpike.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FireStrike; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 50; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelDiamondMace.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelDiamondMace.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DoubleWhirlwindAttack; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 37; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenCompositeLongbow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenCompositeLongbow.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapStamStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 27; } }
 		public override float MlSpeed{ get{ return 4.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenMachete.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenMachete.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ShadowInfectiousStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 41; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenSpellblade.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelElvenSpellblade.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 44; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelLeafblade.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelLeafblade.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapStamStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 42; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelMagicalShortbow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelMagicalShortbow.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.InfectiousStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 38; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelOrnateAxe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelOrnateAxe.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.LightningStriker; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 28; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelRadiantScimitar.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelRadiantScimitar.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FireStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 43; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelRuneBlade.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelRuneBlade.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ToxicStrike; } }
 
 		public override int AosStrengthReq{ get{ return 30; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 35; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelWarCleaver.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelWarCleaver.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.Block; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 48; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelWildStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/ML Weapons/LevelWildStaff.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.PsychicAttack; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 48; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/BaseLevelBashing.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/BaseLevelBashing.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelBashing(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/BaseLevelWhip.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/BaseLevelWhip.cs
@@ -29,6 +29,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelWhip(Serial serial): base(serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelClub.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelClub.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DevastatingBlow; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 44; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelHammerPick.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelHammerPick.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.EarthStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 28; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelHammers.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelHammers.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.NerveStrike; } }
 
 		public override int AosStrengthReq{ get{ return 25; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 40; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelMace.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelMace.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.NerveStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 40; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelMaul.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelMaul.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapManaStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 32; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelScepter.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelScepter.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FreezeStrike; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 30; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelSpikedClub.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelSpikedClub.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.NerveStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 40; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelWarHammer.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelWarHammer.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.RidingAttack; } }
 
 		public override int AosStrengthReq{ get{ return 95; } }
-		public override int AosMinDamage{ get{ return 17; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(17 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 28; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelWarMace.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Maces/LevelWarMace.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.SpinAttack; } }
 
 		public override int AosStrengthReq{ get{ return 80; } }
-		public override int AosMinDamage{ get{ return 16; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 26; } }
 		public override float MlSpeed{ get{ return 4.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/PoleArms/BaseLevelPoleArm.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/PoleArms/BaseLevelPoleArm.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelPoleArm(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelBardiche.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelBardiche.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DoubleStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 17; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(17 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 28; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelHalberd.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelHalberd.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.RidingSwipe; } }
 
 		public override int AosStrengthReq{ get{ return 95; } }
-		public override int AosMinDamage{ get{ return 19; } }
-		public override int AosMaxDamage{ get{ return 20; } }
+		public override int AosMinDamage{ get{ return (int)(19 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(20 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 4.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelScythe.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/PoleArms/LevelScythe.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.LightningStriker; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 32; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/BaseLevelRanged.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/BaseLevelRanged.cs
@@ -29,6 +29,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
 		}
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
 		public BaseLevelRanged( Serial serial ) : base( serial )

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelBow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelBow.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapIntStrike; } }
 
 		public override int AosStrengthReq{ get{ return 30; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 15 : 16; } }
-		public override int AosMaxDamage{ get{ return Core.ML ? 19 : 18; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(15 * GetDamageScaling()) : (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return Core.ML ? (int)(19 * GetDamageScaling()) : (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 4.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelCompositeBow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelCompositeBow.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapManaStrike; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 13 : 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return Core.ML ?  (int)(13 * GetDamageScaling()) : (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 4.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelCrossbow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelCrossbow.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.InfectiousStrike; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 18; } }
-		public override int AosMaxDamage{ get{ return Core.ML ? 22 : 20; } }
+		public override int AosMinDamage{ get{ return (int)(18 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return Core.ML ? (int)(22 * GetDamageScaling()) : (int)(20 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 24; } }
 		public override float MlSpeed{ get{ return 4.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelHeavyCrossbow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelHeavyCrossbow.cs
@@ -18,8 +18,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.Block; } }
 
 		public override int AosStrengthReq{ get{ return 80; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 20 : 19; } }
-		public override int AosMaxDamage{ get{ return Core.ML ? 24 : 20; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(20 * GetDamageScaling()) : (int)(19 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return Core.ML ? (int)(24 * GetDamageScaling()) : (int)(20 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 22; } }
 		public override float MlSpeed{ get{ return 5.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelRepeatingCrossbow.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Ranged/LevelRepeatingCrossbow.cs
@@ -18,8 +18,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapDexStrike; } }
 
 		public override int AosStrengthReq{ get{ return 30; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 8 : 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(8 * GetDamageScaling()) : (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 41; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelBokuto.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelBokuto.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FreezeStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 53; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelDaisho.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelDaisho.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 40; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelKama.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelKama.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.TalonStrike; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 55; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelLajatang.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelLajatang.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapManaStrike; } }
 
 		public override int AosStrengthReq{ get{ return 65; } }
-		public override int AosMinDamage{ get{ return 16; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 32; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelNoDachi.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelNoDachi.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ConsecratedStrike; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 16; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(16 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 35; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelNunchaku.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelNunchaku.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ConsecratedStrike; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 47; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelSai.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelSai.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 15; } }
-		public override int AosMinDamage{ get{ return 9; } }
-		public override int AosMaxDamage{ get{ return 11; } }
+		public override int AosMinDamage{ get{ return (int)(9 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(11 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 55; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTekagi.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTekagi.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ConsecratedStrike; } }
 
 		public override int AosStrengthReq{ get{ return 10; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 53; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTessen.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTessen.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.LightningStriker; } }
 
 		public override int AosStrengthReq{ get{ return 10; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 50; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTetsubo.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelTetsubo.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ElementalStrike; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 45; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelWakizashi.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelWakizashi.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapStamStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 44; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelYumi.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SE Weapons/LevelYumi.cs
@@ -17,8 +17,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DoubleWhirlwindAttack; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return Core.ML ? 16 : 18; } }
-		public override int AosMaxDamage{ get{ return 20; } }
+		public override int AosMinDamage{ get{ return Core.ML ? (int)(16 * GetDamageScaling()) : (int)(18 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(20 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 25; } }
 		public override float MlSpeed{ get{ return 4.5f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/BaseLevelSpear.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/BaseLevelSpear.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelSpear(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelBladedStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelBladedStaff.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.Disarm; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 37; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelDoubleBladedStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelDoubleBladedStaff.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.RidingSwipe; } }
 
 		public override int AosStrengthReq{ get{ return 50; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 49; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelPike.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelPike.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ForceOfNature; } }
 
 		public override int AosStrengthReq{ get{ return 50; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 37; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelPitchfork.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelPitchfork.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.StunningStrike; } }
 
 		public override int AosStrengthReq{ get{ return 55; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(24 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 43; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelShortSpear.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelShortSpear.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.FrenziedWhirlwind; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 55; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelSpear.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelSpear.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DoubleWhirlwindAttack; } }
 
 		public override int AosStrengthReq{ get{ return 50; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 42; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelTribalSpear.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelTribalSpear.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.NerveStrike; } }
 
 		public override int AosStrengthReq{ get{ return 50; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 42; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelWarFork.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/SpearsAndForks/LevelWarFork.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DevastatingBlow; } }
 
 		public override int AosStrengthReq{ get{ return 45; } }
-		public override int AosMinDamage{ get{ return 12; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(12 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 43; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Staves/BaseLevelStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Staves/BaseLevelStaff.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelStaff(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelBlackStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelBlackStaff.cs
@@ -15,8 +15,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.LightningStriker; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 39; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelGnarledStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelGnarledStaff.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.Feint; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 33; } }
 		public override float MlSpeed{ get{ return 3.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelQuarterStaff.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelQuarterStaff.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 30; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 48; } }
 		public override float MlSpeed{ get{ return 2.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelShepherdsCrook.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Staves/LevelShepherdsCrook.cs
@@ -16,8 +16,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.SpinAttack; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 40; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/BaseLevelSword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/BaseLevelSword.cs
@@ -30,6 +30,11 @@ namespace Server.Items
 			ArtifactLevel = 3;
         }
 
+        protected double GetDamageScaling()
+        {
+            return 1.0 + (m_Level / 100.0) * 0.75;
+        }
+
 		public override bool DisplayLootType{ get{ return false; } }
 
         public BaseLevelSword(Serial serial)

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelBoneHarvester.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelBoneHarvester.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.Block; } }
 
 		public override int AosStrengthReq{ get{ return 25; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 36; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelBroadsword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelBroadsword.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 30; } }
-		public override int AosMinDamage{ get{ return 14; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(14 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 33; } }
 		public override float MlSpeed{ get{ return 3.25f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelClaymore.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelClaymore.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 85; } }
-		public override int AosMinDamage{ get{ return 18; } }
-		public override int AosMaxDamage{ get{ return 19; } }
+		public override int AosMinDamage{ get{ return (int)(18 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(19 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 22; } }
 		public override float MlSpeed{ get{ return 4.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelCrescentBlade.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelCrescentBlade.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MagicProtection; } }
 
 		public override int AosStrengthReq{ get{ return 55; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 14; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(14 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 47; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelCutlass.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelCutlass.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ToxicStrike; } }
 
 		public override int AosStrengthReq{ get{ return 25; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 44; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelKatana.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelKatana.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 25; } }
-		public override int AosMinDamage{ get{ return 11; } }
-		public override int AosMaxDamage{ get{ return 13; } }
+		public override int AosMinDamage{ get{ return (int)(11 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(13 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 46; } }
 		public override float MlSpeed{ get{ return 2.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelKryss.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelKryss.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ToxicStrike; } }
 
 		public override int AosStrengthReq{ get{ return 10; } }
-		public override int AosMinDamage{ get{ return 10; } }
-		public override int AosMaxDamage{ get{ return 12; } }
+		public override int AosMinDamage{ get{ return (int)(10 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(12 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 53; } }
 		public override float MlSpeed{ get{ return 2.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelLance.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelLance.cs
@@ -14,8 +14,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 95; } }
-		public override int AosMinDamage{ get{ return 17; } }
-		public override int AosMaxDamage{ get{ return 18; } }
+		public override int AosMinDamage{ get{ return (int)(17 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(18 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 24; } }
 		public override float MlSpeed{ get{ return 4.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelLongsword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelLongsword.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DoubleWhirlwindAttack; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 30; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelScimitar.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelScimitar.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ZapStamStrike; } }
 
 		public override int AosStrengthReq{ get{ return 25; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 37; } }
 		public override float MlSpeed{ get{ return 3.00f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelShortSword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelShortSword.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.ShadowInfectiousStrike; } }
 
 		public override int AosStrengthReq{ get{ return 20; } }
-		public override int AosMinDamage{ get{ return 13; } }
-		public override int AosMaxDamage{ get{ return 15; } }
+		public override int AosMinDamage{ get{ return (int)(13 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(15 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 41; } }
 		public override float MlSpeed{ get{ return 2.75f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelThinLongsword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelThinLongsword.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.DeathBlow; } }
 
 		public override int AosStrengthReq{ get{ return 35; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 16; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(16 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 30; } }
 		public override float MlSpeed{ get{ return 3.50f; } }
 

--- a/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelVikingSword.cs
+++ b/Data/Scripts/Items/Magical/God/Weapons/Swords/LevelVikingSword.cs
@@ -13,8 +13,8 @@ namespace Server.Items
 		public override WeaponAbility FifthAbility{ get{ return WeaponAbility.MeleeProtection2; } }
 
 		public override int AosStrengthReq{ get{ return 40; } }
-		public override int AosMinDamage{ get{ return 15; } }
-		public override int AosMaxDamage{ get{ return 17; } }
+		public override int AosMinDamage{ get{ return (int)(15 * GetDamageScaling()); } }
+		public override int AosMaxDamage{ get{ return (int)(17 * GetDamageScaling()); } }
 		public override int AosSpeed{ get{ return 28; } }
 		public override float MlSpeed{ get{ return 3.75f; } }
 


### PR DESCRIPTION
This change adds a scaling damage bonus to non-jedi legendary artifact weapons. 
The bonus is zero at level 1, and 75% at level 100. 
This is intended to make these weapons interesting and competitive with other endgame weapons once you go through the effort of actually levelling them (which does take time/effort). 
The bonus was kept the same for all weapons, and the GetDamageScaling() function can be altered for individual damage types, but I saw no reason to implement it at this time. 
