### PR TITLE
Send a message informing the player that tools are needed to cook

### DIFF
--- a/Data/Scripts/Items/Food/CookableFood.cs
+++ b/Data/Scripts/Items/Food/CookableFood.cs
@@ -60,15 +60,13 @@ namespace Server.Items
 			}
 		}
 
-#if false
 		public override void OnDoubleClick( Mobile from )
 		{
 			if ( !Movable )
 				return;
 
-			from.Target = new InternalTarget( this );
+			from.SendMessage( "You must use cooking tools to prepare this." );
 		}
-#endif
 
 		public static bool IsHeatSource( object targeted )
 		{


### PR DESCRIPTION
I was confused by the fact that I couldn't double click raw food to cook it like in the original game. I suspect I won't be the last, so thought I'd have the code display a message letting them know.