### PR TITLE
Add option to adjust frequency of random city visitors

### DIFF
--- a/Data/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
+++ b/Data/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
@@ -1135,17 +1135,17 @@ namespace Server.Mobiles
 			for ( int i = 0; i < meetingPets.Count; ++i )
 			{
 				Item spot = ( Item )meetingPets[ i ];
-				if ( MyServerSettings.Humanoid() ){ CreatePets( spot ); }
+				if ( MyServerSettings.RandomCityVisitor() && MyServerSettings.Humanoid() ){ CreatePets( spot ); }
 			}
 			for ( int i = 0; i < meetingLawns.Count; ++i )
 			{
 				Item spot = ( Item )meetingLawns[ i ];
-				CreateCitizenss( spot );
+				if ( MyServerSettings.RandomCityVisitor() ){ CreateCitizenss( spot ); }
 			}
 			for ( int i = 0; i < meetingDemons.Count; ++i )
 			{
 				Item spot = ( Item )meetingDemons[ i ];
-				CreateDaemons( spot );
+				if ( MyServerSettings.RandomCityVisitor() ){ CreateDaemons( spot ); }
 			}
 			CreateDragonRiders();
 		}
@@ -1578,7 +1578,7 @@ namespace Server.Mobiles
 
 		public static bool PeopleMeetingHere( Item spot )
 		{
-			if ( Utility.RandomBool() )
+			if ( Utility.RandomBool() && MyServerSettings.RandomCityVisitor() )
 				return true;
 
 			if ( (Region.Find( spot.Location, spot.Map )).Name == "the Lyceum" ) 

--- a/Data/Scripts/System/Misc/Settings.cs
+++ b/Data/Scripts/System/Misc/Settings.cs
@@ -326,6 +326,11 @@ namespace Server
 			return false;
 		}
 
+		public static bool RandomCityVisitor()
+		{
+			return MySettings.S_RandomCityVisitorsChance > Utility.Random(100);
+		}
+
 		public static bool BlackMarket()
 		{
 			if ( MySettings.S_BlackMarket )

--- a/Info/Scripts/Settings.cs
+++ b/Info/Scripts/Settings.cs
@@ -768,6 +768,11 @@ namespace Server
 
 		public static bool S_Humanoids = true;
 
+	// This setting controls the number of random visitors that will randomly appear in cities e.g.
+	// adventurers that stand around practicing magery. This value is a percentage between 0 and 100
+	// used when determining whether a visitor appear in a spot for the day.
+
+		public static int S_RandomCityVisitorsChance = 50;
 
 
 


### PR DESCRIPTION
I was looking through the server options for a way to tone down the number of other npc adventurers in town because I felt it'd make the NPCs more interesting and engaging. Currently, because there are so many, they don't feel as unique as I think they could be, and they kind of fade into the background. 

I felt it would be nice if there were a scaling factor in server settings to address this, hence this pull request.

