### PR TITLE
adds pack lobsters to the game and their cages, and removes the lobster body id from the pack bear

### DIFF
--- a/Data/Scripts/Items/Containers/AnimalCages.cs
+++ b/Data/Scripts/Items/Containers/AnimalCages.cs
@@ -1464,6 +1464,33 @@ namespace Server.Items
 		} 
 	}
 
+	public class CagedPackLobster : BaseCaged
+	{
+		[Constructable] 
+		public CagedPackLobster()
+		{
+			AnimalType = "PackLobster";
+			Name = "pack lobster";
+			ItemID = Cage( "medium" );
+		}
+
+		public CagedPackLobster( Serial serial ) : base( serial ) 
+		{ 
+		}
+
+		public override void Serialize( GenericWriter writer ) 
+		{ 
+			base.Serialize( writer ); 
+			writer.Write( (int) 0 ); 
+		} 
+
+		public override void Deserialize( GenericReader reader ) 
+		{ 
+			base.Deserialize( reader ); 
+			int version = reader.ReadInt(); 
+		} 
+	}
+
 	public class CagedPackHorse : BaseCaged
 	{
 		[Constructable] 

--- a/Data/Scripts/Mobiles/Animals/Misc/PackLobster.cs
+++ b/Data/Scripts/Mobiles/Animals/Misc/PackLobster.cs
@@ -7,14 +7,14 @@ using Server.ContextMenus;
 
 namespace Server.Mobiles
 {
-	[CorpseName( "a bear corpse" )]
-	public class PackBear : BaseCreature
+	[CorpseName( "a lobster corpse" )]
+	public class PackLobster : BaseCreature
 	{
 		[Constructable]
-		public PackBear() : base( AIType.AI_Animal, FightMode.Aggressor, 10, 1, 0.2, 0.4 )
+		public PackLobster() : base( AIType.AI_Animal, FightMode.Aggressor, 10, 1, 0.2, 0.4 )
 		{
-			Name = "a pack bear";
-			Body = Utility.RandomList( 177, 179 );
+			Name = "a pack lobster";
+			Body = 34;
 			BaseSoundID = 0xA3;
 
 			ControlSlots = 5;
@@ -35,7 +35,7 @@ namespace Server.Mobiles
 			AddItem( pack );
 		}
 
-		public override FoodType FavoriteFood{ get{ return FoodType.Fish | FoodType.Meat | FoodType.FruitsAndVegies; } }
+		public override FoodType FavoriteFood{ get{ return FoodType.Fish; } }
 		public override bool ClickTitle{ get{ return false; } }
 		public override bool ShowFameTitle{ get{ return false; } }
 		public override bool AlwaysAttackable{ get{ return false; } }
@@ -44,7 +44,7 @@ namespace Server.Mobiles
 		public override bool IsBondable{ get{ return true; } }
 		public override bool CanBeRenamedBy( Mobile from ){ return true; }
 
-		public PackBear( Serial serial ) : base( serial )
+		public PackLobster( Serial serial ) : base( serial )
 		{
 		}
 

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -1802,6 +1802,7 @@ namespace Server.Mobiles
 		public static bool AlwaysInvulnerable( Mobile m )
 		{
 			if ( m is PackBear ){ return true; }
+			else if ( m is PackLobster ){ return true; }
 			else if ( m is PackMule ){ return true; }
 			else if ( m is PackStegosaurus ){ return true; }
 			else if ( m is PackTurtle ){ return true; }

--- a/Data/Scripts/System/Misc/ItemSales.cs
+++ b/Data/Scripts/System/Misc/ItemSales.cs
@@ -4113,6 +4113,7 @@ namespace Server
 			new ItemSalesInfo( typeof(	CagedMastadon	),	4520	,	1	,	75	,	false	,	false	,	World.Savage	,	Category.None	,	Material.None	,	Market.Stable	),
 			new ItemSalesInfo( typeof(	CagedMouse	),	107	,	5	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Stable	),
 			new ItemSalesInfo( typeof(	CagedPackBear	),	12500	,	5	,	25	,	false	,	false	,	World.Dread	,	Category.Pack	,	Material.None	,	Market.Animals	),
+			new ItemSalesInfo( typeof(	CagedPackLobster	),	12500	,	5	,	25	,	false	,	false	,	World.Dread	,	Category.Pack	,	Material.None	,	Market.Animals	),
 			new ItemSalesInfo( typeof(	CagedPackHorse	),	631	,	5	,	25	,	false	,	false	,	World.None	,	Category.Pack	,	Material.None	,	Market.Animals	),
 			new ItemSalesInfo( typeof(	CagedPackLlama	),	565	,	5	,	25	,	false	,	false	,	World.Sosaria	,	Category.Pack	,	Material.None	,	Market.Animals	),
 			new ItemSalesInfo( typeof(	CagedPackMule	),	10000	,	5	,	50	,	false	,	false	,	World.None	,	Category.Pack	,	Material.None	,	Market.Animals	),


### PR DESCRIPTION
Previously, this body was one of the possible options for the 'pack bear':
<img width="415" height="200" alt="image" src="https://github.com/user-attachments/assets/618f6e33-64f6-45f1-bb0d-96295447f6f1" />


I created a new item called 'pack lobster' that adds this as a different pack animal, and removed that body option from the pack bear. 