### PR TITLE
removes default enchant from golden ranger gear

### DIFF
--- a/Data/Scripts/Items/Misc/MagicForges.cs
+++ b/Data/Scripts/Items/Misc/MagicForges.cs
@@ -799,7 +799,8 @@ namespace Server.Items
 									{
 										ResourceMods.SetResource( enchant, CraftResource.GildedSpec );
 										Item mod = (Item)enchant;
-										mod = Server.LootPackEntry.Enchant( m, 350, mod );
+										// setting an item as gilded and applying this giant enchant was creating gear that was way too powerful
+										//mod = Server.LootPackEntry.Enchant( m, 350, mod );
 										enchant.InfoText1 = "Golden Rangers";
 										Effects.SendLocationParticles( EffectItem.Create( enchant.Location, enchant.Map, EffectItem.DefaultDuration ), 0x376A, 9, 32, 5008 );
 										Effects.PlaySound( enchant.Location, enchant.Map, 0x1ED );

--- a/Data/Scripts/Items/Misc/MagicForges.cs
+++ b/Data/Scripts/Items/Misc/MagicForges.cs
@@ -795,18 +795,22 @@ namespace Server.Items
 							{
 								foreach ( Item enchant in m.GetItemsInRange( 10 ) )
 								{
-									if ( !enchant.NotModAble && run && enchant.ArtifactLevel == 0 && ( enchant is BaseArmor || enchant is BaseWeapon || enchant is BaseClothing ) && enchant.X>=5203 && enchant.Y>=1301 && enchant.X<=5205 && enchant.Y<=1305 && enchant.Resource != CraftResource.None )
+									if (enchant.Resource == CraftResource.GildedSpec)
 									{
-										ResourceMods.SetResource( enchant, CraftResource.GildedSpec );
-										Item mod = (Item)enchant;
-										// setting an item as gilded and applying this giant enchant was creating gear that was way too powerful
-										//mod = Server.LootPackEntry.Enchant( m, 350, mod );
-										enchant.InfoText1 = "Golden Rangers";
-										Effects.SendLocationParticles( EffectItem.Create( enchant.Location, enchant.Map, EffectItem.DefaultDuration ), 0x376A, 9, 32, 5008 );
-										Effects.PlaySound( enchant.Location, enchant.Map, 0x1ED );
-										RidOf = 1;
-										run = false;
+										m.SendMessage( "This item has already been blessed!" );
 									}
+									else if (!enchant.NotModAble && run && enchant.ArtifactLevel == 0 && (enchant is BaseArmor || enchant is BaseWeapon || enchant is BaseClothing) && enchant.X >= 5203 && enchant.Y >= 1301 && enchant.X <= 5205 && enchant.Y <= 1305 && enchant.Resource != CraftResource.None)
+										{
+											ResourceMods.SetResource(enchant, CraftResource.GildedSpec);
+											Item mod = (Item)enchant;
+											// setting an item as gilded and applying this giant enchant was creating gear that was way too powerful
+											//mod = Server.LootPackEntry.Enchant( m, 350, mod );
+											enchant.InfoText1 = "Golden Rangers";
+											Effects.SendLocationParticles(EffectItem.Create(enchant.Location, enchant.Map, EffectItem.DefaultDuration), 0x376A, 9, 32, 5008);
+											Effects.PlaySound(enchant.Location, enchant.Map, 0x1ED);
+											RidOf = 1;
+											run = false;
+										}
 								}
 
 								if ( RidOf > 0 ){ feath.Delete(); }


### PR DESCRIPTION
setting an item crafting material to gilded gives it many bonuses, slayer types and powerful effects, the extra ridiculously high rerollable enchant made god tier items that could be farmed from killing somewhat unconsequential enemies (plenty of harpies in covetous), which in turn made gearing into a somewhat solved game: instead of adventuring and upgrading your gear, you could get your tracking to 90 while sitting in town, then teleport to covetous with a book in your bag and kill easy monsters until you got a feather, and get yourself one of the best gear pieces you could ever hope for. Didn't get an amazing one? Kill a couple more harpies and reroll it. 
This change removes the enchant roll on the item. 