### PR TITLE
potion of rebirth and soul orb ress timer now at 10 secs (from 30)

### DIFF
--- a/Data/Scripts/Items/Magical/SoulOrb.cs
+++ b/Data/Scripts/Items/Magical/SoulOrb.cs
@@ -23,7 +23,7 @@ namespace Server.Items
         }
 
         private Timer m_Timer;
-        private static TimeSpan m_Delay = TimeSpan.FromSeconds( 30.0 ); /*TimeSpan.Zero*/
+        private static TimeSpan m_Delay = TimeSpan.FromSeconds( 10.0 ); /*TimeSpan.Zero*/
 
         [CommandProperty(AccessLevel.GameMaster)]
         public TimeSpan Delay { get { return m_Delay; } set { m_Delay = value; } }

--- a/Data/Scripts/Items/Potions/Special/AutoResPotion.cs
+++ b/Data/Scripts/Items/Potions/Special/AutoResPotion.cs
@@ -27,7 +27,7 @@ namespace Server.Items
         }
 
         private Timer m_Timer;
-        private static TimeSpan m_Delay = TimeSpan.FromSeconds( 30.0 ); /*TimeSpan.Zero*/
+        private static TimeSpan m_Delay = TimeSpan.FromSeconds( 10.0 ); /*TimeSpan.Zero*/
 
         [CommandProperty(AccessLevel.GameMaster)]
         public TimeSpan Delay { get { return m_Delay; } set { m_Delay = value; } }


### PR DESCRIPTION
Not much of a reason to wait 30 seconds to ress if you have an orb/rebirth queued. Reduced the time it takes by a third. 