### PR TITLE
Improved offensive spell selection for mages, removed invisibility from choice of random spell casts

### DIFF
--- a/Data/Scripts/Magic/Misc/AttackSpells.cs
+++ b/Data/Scripts/Magic/Misc/AttackSpells.cs
@@ -63,7 +63,8 @@ namespace Server.Spells.Magical
 				else if ( magery >= 10 && Caster.Mana >= 9 ){ 			circle = 3; }
 				else if ( Caster.Mana >= 6 && Utility.RandomBool() ){ 	circle = 2; }
 
-				circle = Utility.RandomMinMax( 1, circle );
+				int minCircle = circle / 2 < 1 ? 1 : circle / 2;
+				circle = Utility.RandomMinMax( minCircle , circle );
 
 				if ( circle == 8 ){ 		Caster.Mana = Caster.Mana - 46; }
 				else if ( circle == 7 ){ 	Caster.Mana = Caster.Mana - 36; }

--- a/Data/Scripts/Mobiles/Base/Behavior.cs
+++ b/Data/Scripts/Mobiles/Base/Behavior.cs
@@ -3303,9 +3303,15 @@ namespace Server.Misc
 
 		public static void ChooseFighter( Mobile m, string race )
 		{
-			BaseCreature bc = (BaseCreature)m;
+			BaseCreature bc = m as BaseCreature;
 
-			Region reg = Region.Find( bc.Home, m.Map );
+			if (bc == null || m.Map == null)
+				return;
+
+			Point3D location = (bc.Home != Point3D.Zero) ? bc.Home : m.Location;
+
+			Region reg = Region.Find(location, m.Map);
+			
 
 			int level = 0;
 			int equip = 0;
@@ -9633,7 +9639,7 @@ namespace Server.Mobiles
 							spell = GetRandomManaDrainSpell();
 							break;
 						}
-					case 7:
+					/* case 7:
 						{
 							//m_Mobile.DebugSay( "Attempting to Invis" );
 
@@ -9643,7 +9649,7 @@ namespace Server.Mobiles
 							}
 
 							break;
-						}
+						} */
 
 					default: // Damage them.
 						{


### PR DESCRIPTION
Invisibility was an odd spell in most combat situations because casters would break it immediately on their next onThink(),
I removed it from the random spell casting options.
I also improved the AttackSpells routine by adding a minimum circle to the choice of random spell the opponent will cast, so more powerful mages will no longer spam very weak/low level spells even at very high mana. This will make casters much more dangerous and interesting to engage in a fight. They will still cast harm/magic arrow (or equivalent) on occasion, but are now more likely to resort to more powerful spells in their repertoir.  