### PR TITLE
reduces mercantile bonus to item sale price from 4x item value to 2x sale value

### DIFF
--- a/Data/Scripts/Mobiles/Base/GenericSell.cs
+++ b/Data/Scripts/Mobiles/Base/GenericSell.cs
@@ -30,7 +30,7 @@ namespace Server.Mobiles
 				if ( barter > 0 )
 				{
 					if ( barter > 100 ){ barter = 100; }
-					double nId = 1 + ( barter * 0.03 );
+					double nId = 1 + ( barter * 0.01 );
 					price = (int)(price * nId);
 				}
 				if ( price < 1 )


### PR DESCRIPTION
The mercantile skill (with the added guild bonus) is a money printing machine and adds much more value to a character than its relative difficulty in gaining would accomodate for. 
This changes makes it so that the price caps at 2x original item value instead of 4x original item value for characters with very high barter (mercantile+guild membership). 