### PR TITLE
prevents player from autolooting trapped chests

### DIFF
--- a/Data/Scripts/Items/Containers/DungeonChest.cs
+++ b/Data/Scripts/Items/Containers/DungeonChest.cs
@@ -232,25 +232,28 @@ namespace Server.Items
 
 			if ( CheckLocked( from ) )
 				return;
+			
+			if (PassiveSearching(this, from))
+				return;
 
-			if ( /* from.AccessLevel == AccessLevel.Player && */ ContainerTouched != 1 && !from.Blessed )
+			if ( /* from.AccessLevel == AccessLevel.Player && */ ContainerTouched != 1 && !from.Blessed)
 			{
-				OpenCoffin( from, this.ItemID, ContainerLevel );
+				OpenCoffin(from, this.ItemID, ContainerLevel);
 
 				int FillMeUpLevel = ContainerLevel;
 
-				if ( GetPlayerInfo.LuckyPlayer( from.Luck ) )
+				if (GetPlayerInfo.LuckyPlayer(from.Luck))
 				{
-					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax( 1, 2 );
+					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax(1, 2);
 				}
 
-				ContainerFunctions.FillTheContainer( ContainerLevel, this, from );
+				ContainerFunctions.FillTheContainer(ContainerLevel, this, from);
 
-				LoggingFunctions.LogLoot( from, this.Name, "box" );
-				StandardQuestFunctions.CheckTarget( from, null, this );
+				LoggingFunctions.LogLoot(from, this.Name, "box");
+				StandardQuestFunctions.CheckTarget(from, null, this);
 				ContainerTouched = 1;
 				RemoveBox();
-				Server.Misc.PlayerSettings.LootContainer( from, this );
+				Server.Misc.PlayerSettings.LootContainer(from, this);
 			}
 
 			base.Open( from );

--- a/Data/Scripts/Items/Containers/LandChest.cs
+++ b/Data/Scripts/Items/Containers/LandChest.cs
@@ -49,20 +49,23 @@ namespace Server.Items
 
 		public override void Open( Mobile from )
 		{
-			if ( this.Weight > 20 )
-			{
-				int FillMeUpLevel = Utility.RandomList( 5, 4, 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 1 );
+			if (PassiveSearching(this,from))
+				return;
 
-				if ( GetPlayerInfo.LuckyPlayer( from.Luck ) )
+			if (this.Weight > 20)
+			{
+				int FillMeUpLevel = Utility.RandomList(5, 4, 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 1);
+
+				if (GetPlayerInfo.LuckyPlayer(from.Luck))
 				{
-					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax( 1, 2 );
+					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax(1, 2);
 				}
 
-				ContainerFunctions.FillTheContainer( FillMeUpLevel, this, from );
+				ContainerFunctions.FillTheContainer(FillMeUpLevel, this, from);
 
 				this.Weight = 5.0;
-				if ( isBody ( this.ItemID ) ){ LoggingFunctions.LogLoot( from, this.Name, "corpse" ); }
-				else { ContainerFunctions.FillTheContainer( FillMeUpLevel, this, from ); LoggingFunctions.LogLoot( from, this.Name, "wagon" ); }
+				if (isBody(this.ItemID)) { LoggingFunctions.LogLoot(from, this.Name, "corpse"); }
+				else { ContainerFunctions.FillTheContainer(FillMeUpLevel, this, from); LoggingFunctions.LogLoot(from, this.Name, "wagon"); }
 			}
 
 			base.Open( from );

--- a/Data/Scripts/Items/Containers/SunkenShip.cs
+++ b/Data/Scripts/Items/Containers/SunkenShip.cs
@@ -28,17 +28,20 @@ namespace Server.Items
 
 		public override void Open( Mobile from )
 		{
-			if ( this.Weight > 50 )
+			if (PassiveSearching(this, from))
+				return;
+			
+			if (this.Weight > 50)
 			{
 				int FillMeUpLevel = (int)(this.Weight - 51);
 				this.Weight = 5.0;
 
-				if ( GetPlayerInfo.LuckyPlayer( from.Luck ) )
+				if (GetPlayerInfo.LuckyPlayer(from.Luck))
 				{
-					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax( 1, 2 );
+					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax(1, 2);
 				}
 
-				ContainerFunctions.FillTheContainer( FillMeUpLevel, this, from );
+				ContainerFunctions.FillTheContainer(FillMeUpLevel, this, from);
 			}
 
 			base.Open( from );

--- a/Data/Scripts/Items/Containers/WaterChest.cs
+++ b/Data/Scripts/Items/Containers/WaterChest.cs
@@ -26,16 +26,19 @@ namespace Server.Items
 
 		public override void Open( Mobile from )
 		{
-			if ( this.Weight > 50 )
-			{
-				int FillMeUpLevel = Utility.RandomList( 5, 4, 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 1 );
+			if (PassiveSearching(this, from))
+				return;
 
-				if ( GetPlayerInfo.LuckyPlayer( from.Luck ) )
+			if (this.Weight > 50)
+			{
+				int FillMeUpLevel = Utility.RandomList(5, 4, 4, 3, 3, 3, 2, 2, 2, 2, 1, 1, 1, 1, 1);
+
+				if (GetPlayerInfo.LuckyPlayer(from.Luck))
 				{
-					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax( 1, 2 );
+					FillMeUpLevel = FillMeUpLevel + Utility.RandomMinMax(1, 2);
 				}
 
-				if ( Utility.RandomBool() )
+				if (Utility.RandomBool())
 				{
 					int[] list = new int[]
 						{
@@ -44,15 +47,15 @@ namespace Server.Items
 							0x1B0D, 0x1B0E, 0x1B0F, 0x1B10,
 						};
 
-					Item bones = new BodyPart( Utility.RandomList( list ) );
-					bones.Name = ContainerFunctions.GetOwner( "BodySailor" );
-					this.DropItem( bones );
+					Item bones = new BodyPart(Utility.RandomList(list));
+					bones.Name = ContainerFunctions.GetOwner("BodySailor");
+					this.DropItem(bones);
 				}
 
-				ContainerFunctions.FillTheContainer( FillMeUpLevel, this, from );
+				ContainerFunctions.FillTheContainer(FillMeUpLevel, this, from);
 
 				this.Weight = 5.0;
-				LoggingFunctions.LogLoot( from, this.Name, "boat" );
+				LoggingFunctions.LogLoot(from, this.Name, "boat");
 			}
 
 			base.Open( from );


### PR DESCRIPTION
the [loot command has a funny interaction with trapped chests. It will scoop up itens inside of it when you attempt to open it, before triggeting the actual chest opening. This change fixes it. 