### PR TITLE
slightly reduced the number of max random props that rolls on items

### DIFF
--- a/Data/Scripts/Items/Containers/LootPack.cs
+++ b/Data/Scripts/Items/Containers/LootPack.cs
@@ -617,7 +617,7 @@ namespace Server
 		{
 			if ( item != null )
 			{
-				int props = Utility.RandomMinMax( (int)(enchant/100), (int)(enchant/50) );
+				int props = Utility.RandomMinMax( (int)(enchant/100), (int)(enchant/60) );
 					if ( props < 1 )
 						return item;
 


### PR DESCRIPTION
This is step nº 68 of the ongoing struggle to reduce random bloat on tooltips. 
What this change does is reduce the number of random props that show up on items slightly (from 16 maximum props to 8 on a base 500 enchant value). Notably, it makes lower end enchanted items slightly weaker, while making very little difference for higher end ones that would invariably roll a bunch of random junk that would make little to no difference to the player. 
With this change, it will be harder to 'finish' a build with random drops because of the lack of random props filling gaps, but it will also make well rolled items much more valuable. 