### PR TITLE
hiding now has a 5 seconds cooldown

### DIFF
--- a/Data/Scripts/System/Skills/Hiding.cs
+++ b/Data/Scripts/System/Skills/Hiding.cs
@@ -92,7 +92,7 @@ namespace Server.SkillHandlers
 
 				m.LocalOverheadMessage( MessageType.Regular, 0x22, 501237 ); // You can't seem to hide right now.
 
-				return TimeSpan.FromSeconds( 1.0 );
+				return TimeSpan.FromSeconds( 5.0 );
 			}
 			else 
 			{
@@ -119,7 +119,7 @@ namespace Server.SkillHandlers
 					m.LocalOverheadMessage( MessageType.Regular, 0x22, 501241 ); // You can't seem to hide here.
 				}
 
-				return TimeSpan.FromSeconds( 2.0 );
+				return TimeSpan.FromSeconds( 5.0 );
 			}
 		}
 	}


### PR DESCRIPTION
Currently, hiding is extremely spammable and can trivialize many encounters. Adding a short cooldown to shake things up and make people move around a bit more when fighting. 