### PR TITLE
pack horses max weight reduced 10x

### DIFF
--- a/Data/Scripts/Items/Containers/Container.cs
+++ b/Data/Scripts/Items/Containers/Container.cs
@@ -466,7 +466,7 @@ namespace Server.Items
 			return base.CheckHold( m, item, false, checkItems, plusItems, plusWeight );
 		}
 
-		public override int DefaultMaxWeight{ get{ return 65000; } }
+		public override int DefaultMaxWeight{ get{ return 6500; } }
 
 		public override bool CheckContentDisplay( Mobile from )
 		{


### PR DESCRIPTION
A pack horse being able to carry 65000 stones worth of stuff has been...difficult... in the past. 
I'm greatly reducing their ability to carry entire dragon hoards in order to picking loot in a dungeon somewhat interactable instead of being a question of just vacuum'ing everything and sorting it later. 