### PR TITLE
Disenchanting

### DIFF
--- a/Data/Scripts/Custom/Defender of the Realm/Knights/DefenderOfTheRealm.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/Knights/DefenderOfTheRealm.cs
@@ -92,19 +92,16 @@ namespace Server.Custom.DefenderOfTheRealm.Knight
           
             if( e.Mobile.InRange( this, 4 ))
 			{
-			    if ( ( e.Speech.ToLower() == "reward" ) )
+			    if ( e.Speech.IndexOf("reward") >= 0 )
 			    {
-			        if (e.Speech.IndexOf("reward") >= 0)
+			        if (from.Karma > 0)
                     {
-                        if (from.Karma > 0)
-                        {
-                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, true, 0));
-                            Say("These are the rewards I can offer thee.");
-                        }
-                        else
-                        {
-                            Say("I shall not offer my services to servants of evil! Redeem thyself!");
-                        }
+                        from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, true, 0));
+                        Say("These are the rewards I can offer thee.");
+                    }
+                    else
+                    {
+                        Say("I shall not offer my services to servants of evil! Redeem thyself!");
                     }
 			    }
 			    else 

--- a/Data/Scripts/Custom/Defender of the Realm/Knights/ScourgeOfRealm.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/Knights/ScourgeOfRealm.cs
@@ -188,19 +188,16 @@ namespace Server.Custom.DefenderOfTheRealm.Scourge
           
             if( e.Mobile.InRange( this, 4 ))
 			{
-			    if ( ( e.Speech.ToLower() == "reward" ) )
+			    if ( e.Speech.IndexOf("reward") >= 0 )
 			    {
-			        if (e.Speech.IndexOf("reward") >= 0)
+			        if (from.Karma < 0)
                     {
-                        if (from.Karma < 0)
-                        {
-                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, false, 0));
-                            Say("These are the rewards I can offer thee.");
-                        }
-                        else
-                        {
-                            Say("I shall not offer my services to slaves of Virtue!");
-                        }
+                        from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, false, 0));
+                        Say("These are the rewards I can offer thee.");
+                    }
+                    else
+                    {
+                        Say("I shall not offer my services to slaves of Virtue!");
                     }
 			    }
 			    else 

--- a/Data/Scripts/Custom/Defender of the Realm/System/RewardInfo.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/System/RewardInfo.cs
@@ -12,8 +12,9 @@ namespace Server.Custom.DefenderOfTheRealm
         public string Name;
         public bool Hueable;
         public int Hue;
+        public object[] Args;
 
-        public RewardInfo(Type type, int cost, int itemID, string name, bool hueable, int hue)
+        public RewardInfo(Type type, int cost, int itemID, string name, bool hueable, int hue,params object[] args)
         {
             ItemType = type;
             Cost = cost;
@@ -21,11 +22,12 @@ namespace Server.Custom.DefenderOfTheRealm
             Name = name;
             Hueable = hueable;
             Hue = hue;
+            Args = args; //amount
         }
 
         public Item CreateItem(bool isDefender)
         {
-            Item item = (Item)Activator.CreateInstance(ItemType);
+            Item item = (Item)Activator.CreateInstance(ItemType, Args);
 
             if (Hueable)
             {

--- a/Data/Scripts/Custom/Defender of the Realm/System/RewardTables.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/System/RewardTables.cs
@@ -14,6 +14,7 @@ namespace Server.Custom.DefenderOfTheRealm
         public string Name; <-- item name
         public bool Hueable; <-- sets default hue for the npc faction
         public int Hue <-- 0 for faction items, hue for items with hardcoded hues;
+        public object[] Args; <-- sets amount of items
          */
         public static RewardInfo[] CommonRewards = new RewardInfo[]
         {
@@ -31,7 +32,8 @@ namespace Server.Custom.DefenderOfTheRealm
             new RewardInfo(typeof(EtherealReptalon), 500, 0x2D95, "Ethereal Reptalon",true,0),
             new RewardInfo(typeof(EtherealHorse), 250, 0x20DD, "Ethereal Horse",true,0),
             new RewardInfo(typeof(EtherealLlama), 250, 0x20F6, "Ethereal Llama",true,0),
-            new RewardInfo(typeof(EtherealOstard), 250, 0x2135, "Ethereal Ostard",true,0)
+            new RewardInfo(typeof(EtherealOstard), 250, 0x2135, "Ethereal Ostard",true,0),
+            new RewardInfo(typeof(ArcaneDust), 50, 12265, "100 Arcane Dust",false,33,100)
         };
 
         public static RewardInfo[] DefenderRewards = new RewardInfo[]

--- a/Data/Scripts/Custom/Systems/DisenchantingSystem.cs
+++ b/Data/Scripts/Custom/Systems/DisenchantingSystem.cs
@@ -258,7 +258,7 @@ namespace Server.Misc
 
             }
 
-            if (item is BaseWeapon || item is BaseArmor || item is BaseTrinket || item is BaseClothing || item is Spellbook || item is BaseShield)
+            if (item is BaseWeapon || item is BaseArmor || item is BaseTrinket || item is BaseClothing || item is Spellbook || item is BaseShield || item is BaseInstrument)
             {
                 AosAttributes a = null;
                 try

--- a/Data/Scripts/Custom/Systems/DisenchantingSystem.cs
+++ b/Data/Scripts/Custom/Systems/DisenchantingSystem.cs
@@ -1,0 +1,398 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Server;
+using Server.Items;
+using Server.Gumps;
+using Server.Mobiles;
+using Server.Targeting;
+
+namespace Server.Misc
+{
+    public class DisenchantingSystem
+    {
+        private static readonly string[] InvalidNames = new string[]
+        { //non-identified items are implemented in a really weird way and the cleanest way to check for them if direct name check
+            "an odd item",
+            "an unusual item",
+            "a bizarre item",
+            "a curious item",
+            "a peculiar item",
+            "a strange item",
+            "a weird item"
+        };
+
+        public static void HandleTarget(Mobile from, Item target, Item wand)
+        {
+            if (from == null || wand == null || wand.Deleted)
+                return;
+
+            int charges = GetCharges(wand);
+            if (charges <= 0)
+            {
+                from.SendMessage("The wand has no remaining charges.");
+                wand.Delete();
+                return;
+            }
+            if (target is Container)
+            {
+                if (target.Name != null)
+                {
+                    for (int i = 0; i < InvalidNames.Length; i++)
+                    {
+                        if (target.Name.Equals(InvalidNames[i], StringComparison.OrdinalIgnoreCase))
+                        {
+                            from.SendMessage("You cannot disenchant unidentified items.");
+                            return;
+                        }
+                    }
+                }
+
+                Container cont = (Container)target;
+
+                if (!cont.IsChildOf(from.Backpack))
+                {
+                    from.SendMessage("You can only disenchant containers in your backpack.");
+                    return;
+                }
+
+                from.SendGump(new ConfirmDisenchantGump(from, cont, wand));
+                return;
+            }
+
+            if (!IsDisenchantable(target))
+            {
+                from.SendMessage("That cannot be disenchanted.");
+                return;
+            }
+
+            int dust = GetArcaneDustValue(target);
+            if (dust <= 0)
+            {
+                from.SendMessage("The power of this item is too faint to produce arcane dust.");
+                return;
+            }
+
+            ConsumeCharge(wand, from);
+            target.Delete();
+
+            GiveArcaneDust(from, dust);
+            from.SendMessage("{0} crumbled into {1} arcane dust.", target.Name != null ? target.Name : "An item", dust);
+        }
+
+        public static void DisenchantContainer(Mobile from, Container cont, Item wand)
+        {
+            if (from == null || cont == null || wand == null || wand.Deleted)
+                return;
+
+            int charges = GetCharges(wand);
+            if (charges <= 0)
+            {
+                from.SendMessage("The wand has no remaining charges.");
+                wand.Delete();
+                return;
+            }
+
+            ArrayList validItems = new ArrayList();
+            foreach (Item item in cont.Items)
+            {
+                if (IsDisenchantable(item))
+                    validItems.Add(item);
+            }
+
+            if (validItems.Count == 0)
+            {
+                from.SendMessage("No valid items found to disenchant.");
+                return;
+            }
+
+            int totalDust = 0;
+            int disenchanted = 0;
+
+            for (int i = 0; i < validItems.Count; i++)
+            {
+                if (charges <= 0)
+                {
+                    from.SendMessage("You could not finish your task because your wand has run out of charges.");
+                    break;
+                }
+
+                Item item = (Item)validItems[i];
+                int dust = GetArcaneDustValue(item);
+
+                if (dust > 0)
+                {
+                    totalDust += dust;
+                    disenchanted++;
+                    item.Delete();
+                    charges--;
+                }
+            }
+
+            if (disenchanted > 0)
+            {
+                GiveArcaneDust(from, totalDust);
+                from.SendMessage("{0} item{1} crumbled into {2} arcane dust.", disenchanted, disenchanted != 1 ? "s" : "", totalDust);
+            }
+
+            SetCharges(wand, charges);
+
+            if (charges <= 0)
+            {
+                from.SendMessage("The wand has exhausted its unraveling powers and has ceased to be.");
+                wand.Delete();
+            }
+        }
+
+        private static bool IsDisenchantable(object o)
+        {
+            if (!(o is Item))
+                return false;
+
+            Item item = (Item)o;
+            // can't disenchant unidentified items
+            if (item.Name != null)
+            {
+                for (int i = 0; i < InvalidNames.Length; i++)
+                {
+                    if (item.Name.Equals(InvalidNames[i], StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            if (item.LootType == LootType.Blessed)
+                return false;
+
+            // can't disenchant arties
+            try
+            {
+                System.Reflection.PropertyInfo p = item.GetType().GetProperty("ArtifactLevel");
+                if (p != null)
+                {
+                    object val = p.GetValue(item, null);
+                    if (val is int && (int)val > 0)
+                        return false;
+                }
+            }
+            catch { }
+
+            return (item is BaseWeapon || item is BaseArmor || item is BaseTrinket || item is BaseClothing);
+        }
+
+        private static void GiveArcaneDust(Mobile from, int amount)
+        {
+            if (amount <= 0)
+                return;
+
+            ArcaneDust dust = new ArcaneDust(amount);
+            if (!from.AddToBackpack(dust))
+                dust.MoveToWorld(from.Location, from.Map);
+        }
+
+        private static void ConsumeCharge(Item wand, Mobile from)
+        {
+            int charges = GetCharges(wand);
+            charges--;
+
+            if (charges <= 0)
+            {
+                from.SendMessage("The wand has exhausted its unraveling powers and has ceased to be.");
+                wand.Delete();
+                return;
+            }
+
+            SetCharges(wand, charges);
+        }
+
+        private static int GetCharges(Item wand)
+        {
+            System.Reflection.PropertyInfo p = wand.GetType().GetProperty("Charges");
+            if (p != null)
+            {
+                object val = p.GetValue(wand, null);
+                if (val is int)
+                    return (int)val;
+            }
+            return 0;
+        }
+
+        private static void SetCharges(Item wand, int value)
+        {
+            System.Reflection.PropertyInfo p = wand.GetType().GetProperty("Charges");
+            if (p != null)
+                p.SetValue(wand, value, null);
+        }
+
+        public static int GetArcaneDustValue(Item item)
+        {
+            int total = 0;
+
+            if (item is BaseArmor || item is BaseShield)
+            {
+                BaseArmor armor = (BaseArmor)item;
+                if (armor.ArmorAttributes != null && armor.ArmorAttributes.MageArmor == 1)
+                    total += 10;
+            }
+
+            if (item is BaseWeapon)
+            {
+                BaseWeapon weapon = (BaseWeapon)item;
+                total += 3 * (weapon.WeaponAttributes.HitColdArea + weapon.WeaponAttributes.HitDispel + weapon.WeaponAttributes.HitEnergyArea + weapon.WeaponAttributes.HitFireArea +
+                              weapon.WeaponAttributes.HitFireball + weapon.WeaponAttributes.HitHarm + weapon.WeaponAttributes.HitLeechHits + weapon.WeaponAttributes.HitLightning +
+                              weapon.WeaponAttributes.HitLowerAttack + weapon.WeaponAttributes.HitLowerDefend + weapon.WeaponAttributes.HitMagicArrow + weapon.WeaponAttributes.HitLeechMana +
+                              weapon.WeaponAttributes.HitPhysicalArea + weapon.WeaponAttributes.HitPoisonArea + weapon.WeaponAttributes.HitLeechStam);
+
+                if (weapon.WeaponAttributes.MageWeapon == 1)
+                    total += 5;
+                if (weapon.WeaponAttributes.UseBestSkill == 1)
+                    total += 10;
+
+                total += 2 * weapon.WeaponAttributes.SelfRepair;
+                if (weapon.Slayer != SlayerName.None)
+                    total += 20;
+
+                if (weapon.Slayer2 != SlayerName.None)
+                    total += 20;
+
+            }
+
+            if (item is BaseWeapon || item is BaseArmor || item is BaseTrinket || item is BaseClothing || item is Spellbook || item is BaseShield)
+            {
+                AosAttributes a = null;
+                try
+                {
+                    System.Reflection.PropertyInfo p = item.GetType().GetProperty("Attributes");
+                    if (p != null)
+                        a = (AosAttributes)p.GetValue(item, null);
+                }
+                catch { }
+
+                if (a != null)
+                {
+                    total += 8 * a.DefendChance;
+                    total += 2 * a.EnhancePotions;
+                    total += 20 * a.CastRecovery;
+                    total += 20 * a.CastSpeed;
+                    total += 10 * a.AttackChance;
+                    total += 10 * a.BonusDex;
+                    total += 5 * a.BonusHits;
+                    total += 10 * a.BonusInt;
+                    total += 5 * a.LowerManaCost;
+                    total += 5 * a.LowerRegCost;
+                    total += 2 * a.Luck;
+                    total += 5 * a.BonusMana;
+                    total += 5 * a.RegenMana;
+                    total += 2 * a.ReflectPhysical;
+                    total += 5 * a.RegenStam;
+                    total += 5 * a.RegenHits;
+                    total += 5 * a.SpellDamage;
+                    total += 5 * a.BonusStam;
+                    total += 10 * a.BonusStr;
+                    total += 6 * a.WeaponSpeed;
+                    if (a.NightSight == 1) total += 6;
+                    if (a.SpellChanneling == 1) total += 15;
+                }
+
+                try
+                {//need to cast everything to check for skill bonuses because runUO is very picky about this
+                    SkillName skill;
+                    double bonus;
+
+                    if (item is BaseArmor)
+                    {
+                        BaseArmor armor = (BaseArmor)item;
+                        for (int i = 0; i < 5; i++)
+                        {
+                            armor.SkillBonuses.GetValues(i, out skill, out bonus);
+                            if (bonus > 0)
+                                total += (int)(bonus * 3);
+                        }
+                    }
+                    else if (item is BaseWeapon)
+                    {
+                        BaseWeapon weap = (BaseWeapon)item;
+                        for (int i = 0; i < 5; i++)
+                        {
+                            weap.SkillBonuses.GetValues(i, out skill, out bonus);
+                            if (bonus > 0)
+                                total += (int)(bonus * 3);
+                        }
+                    }
+                    else if (item is BaseClothing)
+                    {
+                        BaseClothing cloth = (BaseClothing)item;
+                        for (int i = 0; i < 5; i++)
+                        {
+                            cloth.SkillBonuses.GetValues(i, out skill, out bonus);
+                            if (bonus > 0)
+                                total += (int)(bonus * 3);
+                        }
+                    }
+                    else if (item is BaseTrinket)
+                    {
+                        BaseTrinket trinket = (BaseTrinket)item;
+                        for (int i = 0; i < 5; i++)
+                        {
+                            trinket.SkillBonuses.GetValues(i, out skill, out bonus);
+                            if (bonus > 0)
+                                total += (int)(bonus * 3);
+                        }
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            int min = 0, max = 0;
+            if (total < 25) { return 0; }
+            else if (total < 50) { min = 1; max = 3; }
+            else if (total < 100) { min = 3; max = 7; }
+            else if (total < 150) { min = 5; max = 11; }
+            else if (total < 200) { min = 8; max = 14; }
+            else if (total < 250) { min = 11; max = 19; }
+            else if (total < 300) { min = 15; max = 25; }
+            else if (total < 350) { min = 20; max = 34; }
+            else if (total < 400) { min = 26; max = 45; }
+            else if (total < 450) { min = 33; max = 57; }
+            else if (total < 500) { min = 41; max = 71; }
+            else { min = 60; max = 90; }
+
+            return Utility.RandomMinMax(min, max);
+        }
+    }
+
+    public class ConfirmDisenchantGump : Gump
+    {
+        private Mobile m_From;
+        private Container m_Container;
+        private Item m_Wand;
+
+        public ConfirmDisenchantGump(Mobile from, Container cont, Item wand) : base(100, 100)
+        {
+            m_From = from;
+            m_Container = cont;
+            m_Wand = wand;
+
+            Closable = true;
+            Dragable = true;
+            AddPage(0);
+            AddBackground(0, 0, 300, 140, 9270);
+            AddHtml(20, 20, 260, 60, "Are you sure? Confirming will disenchant all valid items inside of this container.", true, true);
+            AddButton(40, 100, 4005, 4007, 1, GumpButtonType.Reply, 0);
+            AddLabel(75, 100, 0, "Confirm");
+            AddButton(170, 100, 4005, 4007, 0, GumpButtonType.Reply, 0);
+            AddLabel(205, 100, 0, "Cancel");
+        }
+
+        public override void OnResponse(Server.Network.NetState sender, RelayInfo info)
+        {
+            if (info.ButtonID == 1 && m_From != null && m_Container != null && m_Wand != null)
+            {
+                DisenchantingSystem.DisenchantContainer(m_From, m_Container, m_Wand);
+            }
+        }
+    }
+}

--- a/Data/Scripts/Items/Containers/Loot.cs
+++ b/Data/Scripts/Items/Containers/Loot.cs
@@ -727,7 +727,7 @@ namespace Server
 				typeof( Jar ),					typeof( Bottle ),				typeof( BlankScroll ),			typeof( Feather ),
 				typeof( Shaft ),				typeof( BrittleSkeletal ),		typeof( AmethystBlocks ),		typeof( Sand ),
 				typeof( DemonSkins ),			typeof( RedScales ),			typeof( Log ),					typeof( IronOre ),
-				typeof( Hides )
+				typeof( Hides ),				typeof( ArcaneDust )
 			};
 
 		public static Type[] CraftsTypes{ get{ return m_CraftsTypes; } }

--- a/Data/Scripts/Items/Containers/Loot.cs
+++ b/Data/Scripts/Items/Containers/Loot.cs
@@ -692,7 +692,8 @@ namespace Server
 				typeof( ECrystalAltarDeed ),	typeof( ECrystalBeggarStatueDeed ),		typeof( RunicUndertaker ),
 				typeof( RunicLeatherKit ),		typeof( RunicScales ),					typeof( GolemManual ),
 				typeof( SummonPrison ),			typeof( MagicalWand ),					typeof( MagicalWand ),
-				typeof( BrokenBedDeed ),		typeof( Runebook ),						typeof( FrankenJournalInBox )
+				typeof( BrokenBedDeed ),		typeof( Runebook ),						typeof( FrankenJournalInBox ),
+				typeof( LesserWandOfDisenchanting )
 			};
 
 		public static Type[] RareItemTypes{ get{ return m_RareItemTypes; } }
@@ -713,7 +714,8 @@ namespace Server
 				typeof( CarpetBuild ),			typeof( RunicScales ),					typeof( GolemManual ),
 				typeof( SmallHollowBook ),		typeof( LargeHollowBook ),				typeof( RecallRune),
 				typeof( SlaversNet ),			typeof( TelescopeAddonDeed ),			typeof( RunicUndertaker ),
-				typeof( RunicTinker ),			typeof( RunicSewingKit )				
+				typeof( RunicTinker ),			typeof( RunicSewingKit ), 				typeof( LesserWandOfDisenchanting),
+				typeof( WandOfDisenchanting )				
 			};
 
 		public static Type[] AdventurerRareItemTypes{ get{ return m_RareItemTypes; } }

--- a/Data/Scripts/Items/Trades/disenchanting/ArcaneDust.cs
+++ b/Data/Scripts/Items/Trades/disenchanting/ArcaneDust.cs
@@ -19,6 +19,7 @@ namespace Server.Items
             Amount = amount;
             Weight = 0.1;
         }
+        public override string DefaultDescription{ get{ return"This is the condensed magical essence used in the creation of a magical item. Skilled guild crafters can use it to enhance the properties of magical items."; } }
 
         public ArcaneDust(Serial serial) : base(serial)
         {

--- a/Data/Scripts/Items/Trades/disenchanting/ArcaneDust.cs
+++ b/Data/Scripts/Items/Trades/disenchanting/ArcaneDust.cs
@@ -1,0 +1,39 @@
+using System;
+using Server.Items;
+
+namespace Server.Items
+{
+    public class ArcaneDust : Item
+    {
+        [Constructable]
+        public ArcaneDust() : this(1)
+        {
+        }
+
+        [Constructable]
+        public ArcaneDust(int amount) : base(12265)
+        {
+            Name = "arcane dust";
+            Hue = 33;
+            Stackable = true;
+            Amount = amount;
+            Weight = 0.1;
+        }
+
+        public ArcaneDust(Serial serial) : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/Items/Trades/disenchanting/GreaterWandOfDisenchanting.cs
+++ b/Data/Scripts/Items/Trades/disenchanting/GreaterWandOfDisenchanting.cs
@@ -1,0 +1,90 @@
+using System;
+using Server;
+using Server.Items;
+using Server.Mobiles;
+using Server.Targeting;
+using Server.Misc;
+
+namespace Server.Items
+{
+    public class GreaterWandOfDisenchanting : Item
+    {
+        private int m_Charges;
+
+        [Constructable]
+        public GreaterWandOfDisenchanting() : base(0xDF5)
+        {
+            Name = "Greater wand of disenchanting";
+            Weight = 1.0;
+            m_Charges = 150;
+            Hue = 1153;
+        }
+
+        public GreaterWandOfDisenchanting(Serial serial) : base(serial)
+        {
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int Charges
+        {
+            get { return m_Charges; }
+            set { m_Charges = value; InvalidateProperties(); }
+        }
+
+        public override string DefaultDescription{ get{ return "This wand is used to unravel magical items and strip them of their essence. It can target a single item, or a bag or container filled with items, doing so will destroy them, and award you with Arcane Dust that skilled guild crafters can use to enhance items, and that is also of great value to powerful wizards. Artifacts and unidentified items can never be disenchanted."; } }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+            list.Add("charges remaining: {0}", m_Charges);
+        }
+
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!IsChildOf(from.Backpack))
+            {
+                from.SendMessage("The wand must be in your backpack to use it.");
+                return;
+            }
+
+            if (m_Charges <= 0)
+            {
+                from.SendMessage("The wand has no remaining charges.");
+                return;
+            }
+
+            from.SendMessage("Select the item or container you wish to disenchant.");
+            from.Target = new DisenchantTarget(this);
+        }
+
+        private class DisenchantTarget : Target
+        {
+            private GreaterWandOfDisenchanting m_Wand;
+
+            public DisenchantTarget(GreaterWandOfDisenchanting wand) : base(10, false, TargetFlags.None)
+            {
+                m_Wand = wand;
+            }
+
+            protected override void OnTarget(Mobile from, object targeted)
+            {
+               Server.Misc.DisenchantingSystem.HandleTarget(from, targeted as Item, m_Wand);
+            }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+            writer.Write(m_Charges);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+            m_Charges = reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/Items/Trades/disenchanting/LesserWandOfDisenchanting.cs
+++ b/Data/Scripts/Items/Trades/disenchanting/LesserWandOfDisenchanting.cs
@@ -1,0 +1,89 @@
+using System;
+using Server;
+using Server.Items;
+using Server.Mobiles;
+using Server.Targeting;
+using Server.Misc;
+
+namespace Server.Items
+{
+    public class LesserWandOfDisenchanting : Item
+    {
+        private int m_Charges;
+
+        [Constructable]
+        public LesserWandOfDisenchanting() : base(0xDF5)
+        {
+            Name = "Lesser wand of disenchanting";
+            Hue = 33;
+            Weight = 1.0;
+            m_Charges = 25;
+        }
+
+        public LesserWandOfDisenchanting(Serial serial) : base(serial)
+        {
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int Charges
+        {
+            get { return m_Charges; }
+            set { m_Charges = value; InvalidateProperties(); }
+        }
+        
+        public override string DefaultDescription{ get{ return "This wand is used to unravel magical items and strip them of their essence. It can target a single item, or a bag or container filled with items, doing so will destroy them, and award you with Arcane Dust that skilled guild crafters can use to enhance items, and that is also of great value to powerful wizards. Artifacts and unidentified items can never be disenchanted."; } }
+        
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+            list.Add("charges remaining: {0}", m_Charges);
+        }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!IsChildOf(from.Backpack))
+            {
+                from.SendMessage("The wand must be in your backpack to use it.");
+                return;
+            }
+
+            if (m_Charges <= 0)
+            {
+                from.SendMessage("The wand has no remaining charges.");
+                return;
+            }
+
+            from.SendMessage("Select the item or container you wish to disenchant.");
+            from.Target = new DisenchantTarget(this);
+        }
+
+        private class DisenchantTarget : Target
+        {
+            private LesserWandOfDisenchanting m_Wand;
+
+            public DisenchantTarget(LesserWandOfDisenchanting wand) : base(10, false, TargetFlags.None)
+            {
+                m_Wand = wand;
+            }
+
+            protected override void OnTarget(Mobile from, object targeted)
+            {
+              Server.Misc.DisenchantingSystem.HandleTarget(from, targeted as Item, m_Wand);
+            }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+            writer.Write(m_Charges);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+            m_Charges = reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/Items/Trades/disenchanting/WandOfDisenchanting.cs
+++ b/Data/Scripts/Items/Trades/disenchanting/WandOfDisenchanting.cs
@@ -1,0 +1,89 @@
+using System;
+using Server;
+using Server.Items;
+using Server.Mobiles;
+using Server.Targeting;
+using Server.Misc;
+
+namespace Server.Items
+{
+    public class WandOfDisenchanting : Item
+    {
+        private int m_Charges;
+
+        [Constructable]
+        public WandOfDisenchanting() : base(0xDF5)
+        {
+            Name = "Wand of disenchanting";
+            Hue = 1350;
+            Weight = 1.0;
+            m_Charges = 75;
+        }
+
+        public WandOfDisenchanting(Serial serial) : base(serial)
+        {
+        }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        public int Charges
+        {
+            get { return m_Charges; }
+            set { m_Charges = value; InvalidateProperties(); }
+        }
+
+        public override string DefaultDescription{ get{ return "This wand is used to unravel magical items and strip them of their essence. It can target a single item, or a bag or container filled with items, doing so will destroy them, and award you with Arcane Dust that skilled guild crafters can use to enhance items, and that is also of great value to powerful wizards. Artifacts and unidentified items can never be disenchanted."; } }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            base.GetProperties(list);
+            list.Add("charges remaining: {0}", m_Charges);
+        }
+
+        public override void OnDoubleClick(Mobile from)
+        {
+            if (!IsChildOf(from.Backpack))
+            {
+                from.SendMessage("The wand must be in your backpack to use it.");
+                return;
+            }
+
+            if (m_Charges <= 0)
+            {
+                from.SendMessage("The wand has no remaining charges.");
+                return;
+            }
+
+            from.SendMessage("Select the item or container you wish to disenchant.");
+            from.Target = new DisenchantTarget(this);
+        }
+
+        private class DisenchantTarget : Target
+        {
+            private WandOfDisenchanting m_Wand;
+
+            public DisenchantTarget(WandOfDisenchanting wand) : base(10, false, TargetFlags.None)
+            {
+                m_Wand = wand;
+            }
+
+            protected override void OnTarget(Mobile from, object targeted)
+            {
+              Server.Misc.DisenchantingSystem.HandleTarget(from, targeted as Item, m_Wand);
+            }
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write(0);
+            writer.Write(m_Charges);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            reader.ReadInt();
+            m_Charges = reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/System/Misc/ItemSales.cs
+++ b/Data/Scripts/System/Misc/ItemSales.cs
@@ -4149,7 +4149,9 @@ namespace Server
 			new ItemSalesInfo( typeof(	Ruby	),	70	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Jeweler	),
 			new ItemSalesInfo( typeof(	Sapphire	),	110	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Jeweler	),
 			new ItemSalesInfo( typeof(	StarSapphire	),	120	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Jeweler	),
-			new ItemSalesInfo( typeof(	Tourmaline	),	80	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Jeweler	)
+			new ItemSalesInfo( typeof(	Tourmaline	),	80	,	15	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Jeweler	),
+			new ItemSalesInfo( typeof(	LesserWandOfDisenchanting	),	1000	,	0	,	0	,	false	,	false	,	World.None	,	Category.Rare	,	Material.None	,	Market.Mage	),
+			new ItemSalesInfo( typeof(	ArcaneDust	),	150	,	0	,	0	,	false	,	false	,	World.None	,	Category.None	,	Material.None	,	Market.Mage	)
 		};
 	}
 }

--- a/Data/Scripts/Trades/Crafting/DefTinkering.cs
+++ b/Data/Scripts/Trades/Crafting/DefTinkering.cs
@@ -312,20 +312,20 @@ namespace Server.Engines.Craft
 			
 			#region Disenchanting Wands
 
-			index = AddCraft(typeof(LesserWandOfDisenchanting), 1011383, "Lesser Wand of Disenchanting", 80.0, 120.0, typeof(ArcaneDust), "Arcane Dust", 25, "");
-			AddSkill(index, SkillName.Magery, 80.0, 100.0);
+			index = AddCraft(typeof(LesserWandOfDisenchanting), 1011383, "Lesser Wand of Disenchanting", 60.0, 80.0, typeof(ArcaneDust), "Arcane Dust", 25, "");
+			AddSkill(index, SkillName.Magery, 60.0, 80.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 5, "");
 			AddRes(index, typeof(Oyster), "Pearl", 1, "");
 			
-			index = AddCraft(typeof(WandOfDisenchanting), 1011383, "Wand of Disenchanting", 100.0, 140.0, typeof(ArcaneDust), "Arcane Dust", 50, "");
-			AddSkill(index, SkillName.Magery, 100.0, 120.0);
+			index = AddCraft(typeof(WandOfDisenchanting), 1011383, "Wand of Disenchanting", 80.0, 100.0, typeof(ArcaneDust), "Arcane Dust", 50, "");
+			AddSkill(index, SkillName.Magery, 80.0, 100.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 10, "");
-			AddRes(index, typeof(Oyster), "Pearl", 3, "");
+			AddRes(index, typeof(Oyster), "Pearl", 2, "");
 			
-			index = AddCraft(typeof(GreaterWandOfDisenchanting), 1011383, "Greater Wand of Disenchanting", 125.0, 160.0, typeof(ArcaneDust), "Arcane Dust", 100, "");
-			AddSkill(index, SkillName.Magery, 125.0, 145.0);
+			index = AddCraft(typeof(GreaterWandOfDisenchanting), 1011383, "Greater Wand of Disenchanting", 105.0, 125.0, typeof(ArcaneDust), "Arcane Dust", 100, "");
+			AddSkill(index, SkillName.Magery, 105.0, 125.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 15, "");
-			AddRes(index, typeof(Oyster), "Pearl", 5, "");
+			AddRes(index, typeof(Oyster), "Pearl", 3, "");
 			
 			#endregion
 

--- a/Data/Scripts/Trades/Crafting/DefTinkering.cs
+++ b/Data/Scripts/Trades/Crafting/DefTinkering.cs
@@ -309,7 +309,28 @@ namespace Server.Engines.Craft
 			#endregion
 
 			/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+			
+			#region Disenchanting Wands
 
+			index = AddCraft(typeof(LesserWandOfDisenchanting), 1011383, "Lesser Wand of Disenchanting", 80.0, 120.0, typeof(ArcaneDust), "Arcane Dust", 25, "");
+			AddSkill(index, SkillName.Magery, 80.0, 100.0);
+			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 5, "");
+			AddRes(index, typeof(Oyster), "Pearl", 1, "");
+			
+			index = AddCraft(typeof(WandOfDisenchanting), 1011383, "Wand of Disenchanting", 100.0, 140.0, typeof(ArcaneDust), "Arcane Dust", 50, "");
+			AddSkill(index, SkillName.Magery, 100.0, 120.0);
+			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 10, "");
+			AddRes(index, typeof(Oyster), "Pearl", 3, "");
+			
+			index = AddCraft(typeof(GreaterWandOfDisenchanting), 1011383, "Greater Wand of Disenchanting", 125.0, 160.0, typeof(ArcaneDust), "Arcane Dust", 100, "");
+			AddSkill(index, SkillName.Magery, 125.0, 145.0);
+			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 15, "");
+			AddRes(index, typeof(Oyster), "Pearl", 5, "");
+			
+			#endregion
+
+			/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+			
 			#region Wooden Items
 
 			AddCraft( typeof( ClockFrame ), 1044042, 1024173, 0.0, 50.0, typeof( Log ), 1015101, 6, 1044351 );

--- a/Data/Scripts/Trades/Crafting/DefTinkering.cs
+++ b/Data/Scripts/Trades/Crafting/DefTinkering.cs
@@ -315,17 +315,17 @@ namespace Server.Engines.Craft
 			index = AddCraft(typeof(LesserWandOfDisenchanting), 1011383, "Lesser Wand of Disenchanting", 60.0, 80.0, typeof(ArcaneDust), "Arcane Dust", 25, "");
 			AddSkill(index, SkillName.Magery, 60.0, 80.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 5, "");
-			AddRes(index, typeof(Oyster), "Pearl", 1, "");
+			AddRes(index, typeof(DispelScroll), "Dispel Scroll", 3, "");
 			
 			index = AddCraft(typeof(WandOfDisenchanting), 1011383, "Wand of Disenchanting", 80.0, 100.0, typeof(ArcaneDust), "Arcane Dust", 50, "");
 			AddSkill(index, SkillName.Magery, 80.0, 100.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 10, "");
-			AddRes(index, typeof(Oyster), "Pearl", 2, "");
+			AddRes(index, typeof(DispelScroll), "Dispel Scroll", 9, "");
 			
 			index = AddCraft(typeof(GreaterWandOfDisenchanting), 1011383, "Greater Wand of Disenchanting", 105.0, 125.0, typeof(ArcaneDust), "Arcane Dust", 100, "");
 			AddSkill(index, SkillName.Magery, 105.0, 125.0);
 			AddRes(index, typeof(ArcaneGem), "Arcane Gem", 15, "");
-			AddRes(index, typeof(Oyster), "Pearl", 3, "");
+			AddRes(index, typeof(DispelScroll), "Dispel Scroll", 21, "");
 			
 			#endregion
 

--- a/Data/Scripts/Trades/Guild/EnhancementGump.cs
+++ b/Data/Scripts/Trades/Guild/EnhancementGump.cs
@@ -26,11 +26,11 @@ namespace Server.Gumps
             AddLabel(224, 12, 0x481, "Equipment Enhancement");
 
             AddLabel(15, 40, 0x481, "Attributes");
-            AddLabel(184, 40, 0x481, "Gold");
+            AddLabel(184, 40, 0x481, "Dust");
             AddLabel(273, 40, 0x481, "Use");
 
             AddLabel(319, 40, 0x481, "Attributes");
-            AddLabel(488, 40, 0x481, "Gold");
+            AddLabel(488, 40, 0x481, "Dust");
             AddLabel(577, 40, 0x481, "Use");
 
             int column = 0;

--- a/Data/Scripts/Trades/Guild/EnhancementStoneProcess.cs
+++ b/Data/Scripts/Trades/Guild/EnhancementStoneProcess.cs
@@ -59,14 +59,14 @@ namespace Server.Items
 			{
 				Owner.SendMessage("This piece of equipment cannot be enhanced with that any further.");
 			}
-            else if (SpendGold(GetCostToUpgrade(handler)))
+            else if (SpendDust(GetCostToUpgrade(handler)))
             {
                 handler.Upgrade(ItemToUpgrade, false);
                 BeginProcess();
             }
         }
 
-        private bool SpendGold(int amount)
+        private bool SpendDust(int amount)
         {
             bool bought = (Owner.AccessLevel >= AccessLevel.GameMaster);
             bool fromBank = false;
@@ -74,12 +74,12 @@ namespace Server.Items
             Container cont = Owner.Backpack;
             if (!bought && cont != null)
             {
-                if (cont.ConsumeTotal(typeof(Gold), amount))
+                if (cont.ConsumeTotal(typeof(ArcaneDust), amount))
                     bought = true;
                 else
                 {
                     cont = Owner.FindBankNoCreate();
-                    if (cont != null && cont.ConsumeTotal(typeof(Gold), amount))
+                    if (cont != null && cont.ConsumeTotal(typeof(ArcaneDust), amount))
                     {
                         bought = true;
                         fromBank = true;
@@ -94,11 +94,11 @@ namespace Server.Items
             if (bought)
             {
                 if (Owner.AccessLevel >= AccessLevel.GameMaster)
-                    Owner.SendMessage("{0} gold would have been withdrawn from your bank if you were not an admin.", amount);
+                    Owner.SendMessage("{0} Arcane Dust would have been withdrawn from your bank if you were not an admin.", amount);
                 else if (fromBank)
-                    Owner.SendMessage("The total of your purchase is {0} gold, which has been withdrawn from your bank account.", amount);
+                    Owner.SendMessage("The total cost of your endeavor is {0} Arcane Dust, which has been withdrawn from your bank account.", amount);
                 else
-                    Owner.SendMessage("The total of your purchase is {0} gold.", amount);
+                    Owner.SendMessage("The total cost of your endeavor is {0} Arcane Dust.", amount);
             }
 
 			PlayerMobile pc = (PlayerMobile)Owner;
@@ -126,8 +126,8 @@ namespace Server.Items
         {
             int attrMultiplier = 1;
 
-			int gold = (int)( (double)BaseCost * ( 1.0 + ( (double)MySettings.S_GuildEnhanceMod / 100.0 ) ) );
-				if ( IsCraftedByEnhancer( ItemToUpgrade, Owner ) ){ gold = (int)( gold / 2 ); }
+			int dust = (int)( (double)BaseCost * ( 1.0 + ( (double)MySettings.S_GuildEnhanceMod / 100.0 ) ) );
+				if ( IsCraftedByEnhancer( ItemToUpgrade, Owner ) ){ dust = (int)( dust / 2 ); }
 
             if (AttrCountAffectsCost)
             {
@@ -143,9 +143,10 @@ namespace Server.Items
             int lvl = handler.Upgrade(ItemToUpgrade, true);
 
 			if ( lvl < max )
-				cost = ((lvl+1)*handler.Cost)*gold;
-
-            cost = (int)(cost * attrMultiplier);
+				cost = ((lvl+1)*handler.Cost)*dust;
+            // original cost quickly scaled up to a couple million gold coins per 1% increase in a prop. 
+            // arcane dust usages should still be expensive, but not prohibitively so. 
+            cost = (int)(cost * attrMultiplier)/50;
 
             return cost;
         }


### PR DESCRIPTION
This adds the disenchanting system in the game, which includes the following:


- Tinkers can craft 3 varieties of wand (lesser, regular, greater), which come with different maximum charges.
<img width="293" height="140" alt="image" src="https://github.com/user-attachments/assets/80ecd69d-822f-4903-a816-8e336c29e9fe" />

The wand can target an item (or container). Upon targetting an equippable, non-artifact, non-unidentified item, the item will be consumed and the player will be awarded with Arcane Dust. 
<img width="208" height="108" alt="image" src="https://github.com/user-attachments/assets/044efa54-88c1-4971-b53d-4ef738d4f497" />

If a container is targgeted, then a confirmation prompt will appear asking the player if its ok to disenchant all items in that container. 
<img width="367" height="183" alt="image" src="https://github.com/user-attachments/assets/777a2a9d-9f29-42a6-9fb5-28ecf5cb4360" />

If the player clicks Confirm, then all valid items will be destroyed and the player will be awarded an amount of Arcane Dust equivalent to what they would get if they had destroyed each item individually. 

Destroying an item costs a charge, once a wand is out of charges it vanishes. Wands (and Dust) can also rarely be found as loot. Lesser Wands and some Arcane Dust can occasionally be sold by Wizards. 

The amount of dusted awarded by an item is calculated based on the intensity of their properties, with stronger items awarding more dust. The game calculates the total 'strength' of an item, and then awards dust using this formula:
<img width="430" height="282" alt="image" src="https://github.com/user-attachments/assets/1468672d-bf39-4385-a905-037471749185" />

Where 'total' is the sum of values attributed by each property. So, at maximum, a player would get 90 Arcane Dust for an amazingly rolled item, but average values are much lower than that. 

For now, the use of Arcane Dust is limited to Guild Enhancing. 
<img width="1098" height="562" alt="image" src="https://github.com/user-attachments/assets/fbfc4d04-2587-47bb-9cfd-ce39fb1c2357" />

The steep gold requirements of enhancing items have been replaced with Dust requirements. Self-crafted items still cost half the total per property, as per the original implementation. 

The goals of this system are the following:
a) Provide an alternate use for dungeon loot for those that are not too concerned with gold.
b) Provide a reason for a crafter to stay in their crafting guild once their skills are high enough. Previously, the only reason for doing so was to use the services of the guildmaster to buy items, which was somewhat meaningless in many circunstances. The guild crafting with gold had costs that were beyond absurd and I dont think that anyone would spend a powerscroll and a half woth of gold to add 1% damage increase to a weapon that they found in a ditch somewhere. But maybe 200 Arcane dust sounds acceptable. 
c) Provide a base for future content. I intend to add more uses for arcane dust and specialized forms of crafting once I'm satisfied with the system and its rates. 
d) make looted and (specially) crafted items more appealing. Artifacts cannot be enhanced with guild tools, but crafted items can. This will lead to a situation in which over time, it will saving up dust to add a couple missing props to an item will make it more appealing than an average artifact, specially after upgrading its material. It also provides a form of continuous progression, because a player that has crafting unlocked will know that every bit of dust they aqquire will be useful in enhancing their character in the future. 

