### PR TITLE
rewrite of the vow reward system, introduction of the shadowbroker items

### DIFF
--- a/Data/Scripts/Custom/Defender of the Realm/Knights/DefenderOfTheRealm.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/Knights/DefenderOfTheRealm.cs
@@ -33,21 +33,12 @@ namespace Server.Custom.DefenderOfTheRealm.Knight
             }
             AddItem( new Boots( Utility.RandomBirdHue() ) );
             AddItem( new Cloak( Utility.RandomBirdHue() ) );
-            Item chest = new PlateChest();
-            chest.Hue = 0x35;
-            AddItem(chest);
-            Item legs = new PlateLegs();
-            legs.Hue = 0x35;
-            AddItem(legs);
-            Item arms = new PlateArms();
-            arms.Hue = 0x35;
-            AddItem(arms);
-            Item gloves = new PlateGloves();
-            gloves.Hue = 0x35;
-            AddItem(gloves);
-            Item gorget = new PlateGorget();
-            gorget.Hue = 0x35;
-            AddItem(gorget);
+            AddItem( new Artifact_DefenderOfTheRealmArms());
+            AddItem( new Artifact_DefenderOfTheRealmChestpiece());
+            AddItem( new Artifact_DefenderOfTheRealmGloves());
+            AddItem( new Artifact_DefenderOfTheRealmGorget());
+            AddItem( new Artifact_DefenderOfTheRealmHelmet());
+            AddItem( new Artifact_DefenderOfTheRealmLeggings());
         }
 
         public override void OnMovement( Mobile m, Point3D oldLocation )
@@ -98,7 +89,7 @@ namespace Server.Custom.DefenderOfTheRealm.Knight
                     {
                         if (from.Karma > 0)
                         {
-                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, true, 0));
+                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, 1, 0));
                             Say("These are the rewards I can offer thee.");
                         }
                         else

--- a/Data/Scripts/Custom/Defender of the Realm/Knights/ScourgeOfRealm.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/Knights/ScourgeOfRealm.cs
@@ -32,21 +32,12 @@ namespace Server.Custom.DefenderOfTheRealm.Scourge
             }
             AddItem( new Boots( Utility.RandomBirdHue() ) );
             AddItem( new Cloak( Utility.RandomBirdHue() ) );
-            Item chest = new PlateChest();
-            chest.Hue = 0x26;
-            AddItem(chest);
-            Item legs = new PlateLegs();
-            legs.Hue = 0x26;
-            AddItem(legs);
-            Item arms = new PlateArms();
-            arms.Hue = 0x26;
-            AddItem(arms);
-            Item gloves = new PlateGloves();
-            gloves.Hue = 0x26;
-            AddItem(gloves);
-            Item gorget = new PlateGorget();
-            gorget.Hue = 0x26;
-            AddItem(gorget);
+            AddItem( new Artifact_ScourgeOfTheRealmArms());
+            AddItem( new Artifact_ScourgeOfTheRealmChestpiece());
+            AddItem( new Artifact_ScourgeOfTheRealmGloves());
+            AddItem( new Artifact_ScourgeOfTheRealmGorget());
+            AddItem( new Artifact_ScourgeOfTheRealmHelmet());
+            AddItem( new Artifact_ScourgeOfTheRealmLeggings());
         }
 
         public override void OnMovement( Mobile m, Point3D oldLocation )
@@ -194,7 +185,7 @@ namespace Server.Custom.DefenderOfTheRealm.Scourge
                     {
                         if (from.Karma < 0)
                         {
-                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, false, 0));
+                            from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, 2, 0));
                             Say("These are the rewards I can offer thee.");
                         }
                         else

--- a/Data/Scripts/Custom/Defender of the Realm/System/RewardInfo.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/System/RewardInfo.cs
@@ -23,13 +23,24 @@ namespace Server.Custom.DefenderOfTheRealm
             Hue = hue;
         }
 
-        public Item CreateItem(bool isDefender)
+        public Item CreateItem(int type)
         {
             Item item = (Item)Activator.CreateInstance(ItemType);
 
             if (Hueable)
             {
-                item.Hue = isDefender ? 0x35 : 0x25;
+                if(type == 1)
+                {
+                    item.Hue = 53;
+                }
+                else if (type == 2)
+                {
+                    item.Hue = 37;
+                }
+                else if (type == 3)
+                {
+                    item.Hue = 1109;
+                }
             }
             return item;
         }

--- a/Data/Scripts/Custom/Defender of the Realm/System/RewardTables.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/System/RewardTables.cs
@@ -53,5 +53,15 @@ namespace Server.Custom.DefenderOfTheRealm
             new RewardInfo(typeof(Artifact_ScourgeOfTheRealmHelmet), 900, 0x1412, "Scourge's Helmet",true,0),
             new RewardInfo(typeof(Artifact_ScourgeOfTheRealmLeggings), 1000, 0x46AA, "Scourge's Leggings",true,0)
         };
+
+        public static RewardInfo[] ShadowbrokerRewards = new RewardInfo[]
+        {
+            new RewardInfo(typeof(Artifact_ShadowBrokerArms), 900, 0x13cd, "Shadow Broker Arms",true,0),
+            new RewardInfo(typeof(Artifact_ShadowBrokerTunic), 1000, 0x13CC, "Shadow Broker Tunic",true,0),
+            new RewardInfo(typeof(Artifact_ShadowBrokerGloves), 900, 0x13C6, "Shadow Broker Gloves",true,0),
+            new RewardInfo(typeof(Artifact_ShadowBrokerGorget), 900, 0x13C7, "Shadow Broker Gorget",true,0),
+            new RewardInfo(typeof(Artifact_ShadowBrokerCap), 900, 0x1DB9, "Shadow Broker Cap",true,0),
+            new RewardInfo(typeof(Artifact_ShadowBrokerLeggings), 1000, 0x13D2, "Shadow Broker Leggings",true,0)
+        };
     }
 }

--- a/Data/Scripts/Custom/Defender of the Realm/System/VowRewardHelper.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/System/VowRewardHelper.cs
@@ -8,7 +8,8 @@ namespace Server.Custom.DefenderOfTheRealm.Vow
     public enum VowType
     {
         Honor,
-        Scourge
+        Scourge,
+        Shadowbroker
     }
 
     public static class VowRewardHelper
@@ -294,7 +295,7 @@ namespace Server.Custom.DefenderOfTheRealm.Vow
                         return new Artifact_DefenderOfTheRealmArms();
                 }
             }
-            else
+            else if (type == VowType.Scourge)
             {
                 switch (Utility.Random(6))
                 {
@@ -314,9 +315,31 @@ namespace Server.Custom.DefenderOfTheRealm.Vow
                         return new Artifact_ScourgeOfTheRealmArms();
                 }
             }
+            else if (type == VowType.Shadowbroker)
+            {
+                switch (Utility.Random(6))
+                {
+                    case 0: 
+                        return new Artifact_ShadowBrokerArms();
+                    case 1: 
+                        return new Artifact_ShadowBrokerTunic();
+                    case 2: 
+                        return new Artifact_ShadowBrokerGloves();
+                    case 3: 
+                        return new Artifact_ShadowBrokerGorget();
+                    case 4: 
+                        return new Artifact_ShadowBrokerCap();
+                    case 5: 
+                        return new Artifact_ShadowBrokerLeggings();
+                    default: //hacky, need to think of a better implementation
+                        return new Artifact_ShadowBrokerArms();
+                }
+            }
 
             if (item != null)
                 return item;
+            else
+                return null;
         }
         public static void GenerateEnchantedItem(Mobile from, int enchantLevel, Container rewardBag)
         {

--- a/Data/Scripts/Custom/Defender of the Realm/Vow Gump/RewardGump.cs
+++ b/Data/Scripts/Custom/Defender of the Realm/Vow Gump/RewardGump.cs
@@ -11,27 +11,61 @@ namespace Server.Custom.DefenderOfTheRealm
     {
         private Mobile m_From;
         private RewardInfo[] m_Rewards;
-        private int m_Page;
-        private bool m_IsDefender;
+        private int m_Page;        
+        /*
+            1 - defender of the realm
+            2 - scourge of the realm
+            3 - thief guildmaster
+        */
+        private int type;
+        private int m_Hue;
+        private int m_Type;
+        private string m_CurrencyType;
 
-        public RewardGump(Mobile from, bool isDefender, int page) : base(50, 50)
+
+        public RewardGump(Mobile from, int type, int page) : base(50, 50)
         {
+            this.type = type;
             m_From = from;
             m_Page = page;
-            m_IsDefender = isDefender;
-
-            AddBackground(0, 0, 420, 420, 9270);
-            AddLabel(160, 20, 1152, isDefender ? "Defender of the Realm Rewards" : "Scourge of the Realm Rewards");
+            m_Type = type;
+            int hue = 0;
 
             List<RewardInfo> list = new List<RewardInfo>();
             list.AddRange(RewardTables.CommonRewards);
-            if (isDefender)
-                list.AddRange(RewardTables.DefenderRewards);
-            else
-                list.AddRange(RewardTables.ScourgeRewards);
+            
+            AddBackground(0, 0, 420, 420, 9270);
+           
+            switch (m_Type)
+            {
+                case 1:
+                    AddLabel(160, 20, 1152, "Defender of the Realm Rewards");
+                    m_CurrencyType = "Marks of Honor";
+                    m_Hue = 53;
+                    list.AddRange(RewardTables.DefenderRewards);
+                    break;
 
+                case 2:
+                    AddLabel(160, 20, 1152, "Scourge of the Realm Rewards");
+                    m_CurrencyType = "Marks of the Scourge";
+                    m_Hue = 37;
+                    list.AddRange(RewardTables.ScourgeRewards);
+                    break;
+
+                case 3:
+                    AddLabel(160, 20, 1152, "Shadowbroker Rewards");
+                    m_CurrencyType = "Marks of the Shadowbroker";
+                    m_Hue = 1109;
+                    list.AddRange(RewardTables.ShadowbrokerRewards);
+                    break;
+
+                default:
+                    AddLabel(160, 20, 1152, "Rewards");
+                    m_CurrencyType = "Marks";
+                    m_Hue = 0;
+                    break;
+            }
             m_Rewards = list.ToArray();
-
             int perPage = 6;
             int start = page * perPage;
             int end = Math.Min(start + perPage, m_Rewards.Length);
@@ -41,24 +75,15 @@ namespace Server.Custom.DefenderOfTheRealm
             {
                 RewardInfo info = m_Rewards[i];
                 int buttonID = 1000 + i;
-                int hue = 0;
-                string currencyType = m_IsDefender ? "Marks of Honor" : "Marks of the Scourge";
-                if (info.Hue > 0)
-                {
-                    hue = info.Hue;
-                }
-                else if (info.Hueable)
-                {
-                    hue = m_IsDefender ? 0x35 : 0x25;
-                }
-
-                AddItem(x, y, info.ItemID,hue);
+                int itemHue = info.Hue > 0 ? info.Hue : (info.Hueable ? m_Hue : 0);
+                AddItem(x, y, info.ItemID, itemHue);
                 AddLabel(x + 50, y, 1152, info.Name);
-                AddLabel(x + 50, y + 20, 1153, "Cost: " + info.Cost+ " " + currencyType);
+                AddLabel(x + 50, y + 20, 1153, "Cost: " + info.Cost + " " + m_CurrencyType);
                 AddButton(x + 300, y, 4005, 4007, buttonID, GumpButtonType.Reply, 0);
 
                 y += 50;
             }
+
 
             if (page > 0)
                 AddButton(100, 380, 4014, 4016, 1, GumpButtonType.Reply, 0); // prev
@@ -69,14 +94,14 @@ namespace Server.Custom.DefenderOfTheRealm
         public override void OnResponse(NetState state, RelayInfo info)
         {
             if (info.ButtonID == 1) // prev
-                m_From.SendGump(new RewardGump(m_From, m_IsDefender, m_Page - 1));
+                m_From.SendGump(new RewardGump(m_From, m_Type, m_Page - 1));
             else if (info.ButtonID == 2) // next
-                m_From.SendGump(new RewardGump(m_From, m_IsDefender, m_Page + 1));
+                m_From.SendGump(new RewardGump(m_From, m_Type, m_Page + 1));
             else if (info.ButtonID >= 1000)
             {
                 int index = info.ButtonID - 1000;
                 if (index >= 0 && index < m_Rewards.Length)
-                    m_From.SendGump(new RewardConfirmGump(m_From, m_Rewards[index], m_IsDefender));
+                    m_From.SendGump(new RewardConfirmGump(m_From, m_Rewards[index], m_Type));
             }
         }
     }

--- a/Data/Scripts/Custom/shadow broker/items/MarksOfTheShadowbroker.cs
+++ b/Data/Scripts/Custom/shadow broker/items/MarksOfTheShadowbroker.cs
@@ -1,0 +1,41 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+    public class MarksOfTheShadowbroker : Item
+    {
+        [Constructable]
+        public MarksOfTheShadowbroker() : this(1)
+        {
+        }
+        
+        public override string DefaultDescription{ get{ return "A Mark of the Shadowbroker represents your prowess as a thief. It can be aqquired by burglars as they adventure and filfer the pockets of their victims. The guildmaster of the thieves guild can offer many trinkets for those that would speak of rewards with them."; } }
+
+        [Constructable]
+        public MarksOfTheShadowbroker(int amount) : base(0x2ff8)
+        {
+            Stackable = true;
+            Weight = 0.1;
+            Hue = 0x455;
+            Amount = amount;
+            Name = "Mark of the Shadow Broker";
+        }
+
+        public MarksOfTheShadowbroker(Serial serial) : base(serial)
+        {
+        }
+
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+            writer.Write((int)0);
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+            int version = reader.ReadInt();
+        }
+    }
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerArms.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerArms.cs
@@ -1,0 +1,48 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerArms : GiftLeatherArms
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 13; } }
+		public override int BasePoisonResistance{ get{ return 15; } }
+		public override int BaseEnergyResistance{ get{ return 15; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerArms()
+		{
+			Name = "Shadow Broker Arms";
+			Hue = 0x455;
+			ItemID = 0x13cd;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 10.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 10.0 );
+			Attributes.BonusDex = 5;
+			Attributes.Luck = 95;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerArms( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerCap.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerCap.cs
@@ -1,0 +1,47 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerCap : GiftLeatherCap
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 10; } }
+		public override int BasePoisonResistance{ get{ return 13; } }
+		public override int BaseEnergyResistance{ get{ return 13; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerCap()
+		{
+			Name = "Shadow Broker Cap";
+			Hue = 0x455;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 10.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 10.0 );
+			Attributes.BonusDex = 5;
+			Attributes.Luck = 95;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerCap( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerGloves.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerGloves.cs
@@ -1,0 +1,48 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerGloves : GiftLeatherGloves
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 13; } }
+		public override int BasePoisonResistance{ get{ return 15; } }
+		public override int BaseEnergyResistance{ get{ return 15; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerGloves()
+		{
+			Name = "Shadow Broker Gloves";
+			Hue = 0x455;
+			ItemID = 0x13C6;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 10.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 10.0 );
+			Attributes.BonusDex = 6;
+			Attributes.Luck = 90;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerGloves( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerGorget.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerGorget.cs
@@ -1,0 +1,48 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerGorget : GiftLeatherGorget
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 15; } }
+		public override int BasePoisonResistance{ get{ return 17; } }
+		public override int BaseEnergyResistance{ get{ return 17; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerGorget()
+		{
+			Name = "Shadow Broker Gorget";
+			Hue = 0x455;
+			ItemID = 0x13C7;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 10.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 10.0 );
+			Attributes.BonusDex = 3;
+			Attributes.Luck = 105;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerGorget( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerLeggings.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerLeggings.cs
@@ -1,0 +1,47 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerLeggings : GiftLeatherLegs
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 17; } }
+		public override int BasePoisonResistance{ get{ return 18; } }
+		public override int BaseEnergyResistance{ get{ return 18; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerLeggings()
+		{
+			Name = "Shadow Broker Leggings";
+			ItemID = 0x13D2;
+			Hue = 0x455;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 20.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 20.0 );
+			Attributes.Luck = 90;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerLeggings( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerTunic.cs
+++ b/Data/Scripts/Items/Magical/Artifacts/Main/armor/Artifact_ShadowBrokerTunic.cs
@@ -1,0 +1,48 @@
+using System;
+using Server;
+
+namespace Server.Items
+{
+	public class Artifact_ShadowBrokerTunic : GiftLeatherChest
+	{
+		public override int InitMinHits{ get{ return 80; } }
+		public override int InitMaxHits{ get{ return 160; } }
+
+		public override int BasePhysicalResistance{ get{ return 19; } }
+		public override int BasePoisonResistance{ get{ return 21; } }
+		public override int BaseEnergyResistance{ get{ return 21; } }
+
+		[Constructable]
+		public Artifact_ShadowBrokerTunic()
+		{
+			Name = "Shadow Broker Tunic";
+			Hue = 0x455;
+			ItemID = 0x13CC;
+			SkillBonuses.SetValues( 0, SkillName.Mercantile, 10.0 );
+			SkillBonuses.SetValues( 1, SkillName.Stealing, 10.0 );
+			Attributes.BonusDex = 6;
+			Attributes.Luck = 90;
+			ArtifactLevel = 2;
+			Server.Misc.Arty.ArtySetup( this, 10, "" );
+		}
+
+		public Artifact_ShadowBrokerTunic( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 1 );
+		}
+		
+		public override void Deserialize(GenericReader reader)
+		{
+			base.Deserialize( reader );
+			ArtifactLevel = 2;
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -6317,7 +6317,7 @@ namespace Server.Mobiles
 			int x = System.Math.Abs( this.X - attacker.X );
 			int y = System.Math.Abs( this.Y - attacker.Y );
 
-			if ( m_Coins > 0 && x < 2 && y < 2 && attacker is PlayerMobile && stealing >= 20.0 && level < stealing && snooping > Utility.RandomMinMax(20, 126) )
+			if ( m_Coins > 0 && x < 2 && y < 2 && attacker is PlayerMobile && stealing >= 50.0 && level < stealing && snooping > Utility.RandomMinMax(20, 126) )
 			{
 				int coins = m_Coins * ( 1 - ( level / stealing ) );
 				if ( coins < 1 )
@@ -6326,18 +6326,13 @@ namespace Server.Mobiles
 				coins = Utility.RandomMinMax( 1, coins );
 
 				m_Coins = m_Coins - coins;
+
 				if ( m_Coins < 0 )
 					m_Coins = 0;
-
-				if ( m_CoinType == "xormite" )
-					attacker.AddToBackpack( new DDXormite( coins ) );
-				else if ( m_CoinType == "crystals" )
-					attacker.AddToBackpack( new Crystals( coins ) );
-				else if ( m_CoinType == "jewels" )
-					attacker.AddToBackpack( new DDJewels( coins ) );
-				else
-					attacker.AddToBackpack( new Gold( coins ) );
-
+				if (attacker is PlayerMobile && ((PlayerMobile)attacker).NpcGuild == NpcGuild.ThievesGuild)
+				{
+					attacker.AddToBackpack( new MarksOfTheShadowbroker( coins ) );	
+				}
 				string stole = "stolen";
 				switch ( Utility.RandomMinMax( 0, 7 ) ) 
 				{
@@ -6350,7 +6345,7 @@ namespace Server.Mobiles
 					case 7: stole = "snatched"; break;
 				}
 
-				attacker.SendMessage( "You " + stole + " " + coins + " " + m_CoinType + "!" );
+				attacker.SendMessage( "You " + stole + " " + coins + " " + "Marks of the Shadow Broker!" );
 
 				if ( this.Karma > 0 )
 					Titles.AwardKarma( attacker, -coins, false );

--- a/Data/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/Data/Scripts/Mobiles/Base/BaseCreature.cs
@@ -6317,7 +6317,8 @@ namespace Server.Mobiles
 			int x = System.Math.Abs( this.X - attacker.X );
 			int y = System.Math.Abs( this.Y - attacker.Y );
 
-			if ( m_Coins > 0 && x < 2 && y < 2 && attacker is PlayerMobile && stealing >= 50.0 && level < stealing && snooping > Utility.RandomMinMax(20, 126) )
+			if ( m_Coins > 0 && x < 2 && y < 2 && attacker is PlayerMobile && ((PlayerMobile)attacker).NpcGuild == NpcGuild.ThievesGuild 
+				&& stealing >= 50.0 && level < stealing && snooping > Utility.RandomMinMax(20, 126) )
 			{
 				int coins = m_Coins * ( 1 - ( level / stealing ) );
 				if ( coins < 1 )
@@ -6329,10 +6330,9 @@ namespace Server.Mobiles
 
 				if ( m_Coins < 0 )
 					m_Coins = 0;
-				if (attacker is PlayerMobile && ((PlayerMobile)attacker).NpcGuild == NpcGuild.ThievesGuild)
-				{
-					attacker.AddToBackpack( new MarksOfTheShadowbroker( coins ) );	
-				}
+				
+				attacker.AddToBackpack( new MarksOfTheShadowbroker( coins ) );	
+				
 				string stole = "stolen";
 				switch ( Utility.RandomMinMax( 0, 7 ) ) 
 				{

--- a/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
+++ b/Data/Scripts/Mobiles/Civilized/Guilds/ThiefGuildmaster.cs
@@ -8,6 +8,7 @@ using Server.ContextMenus;
 using Server.Gumps;
 using Server.Misc;
 using Server.Mobiles;
+using Server.Custom.DefenderOfTheRealm.Vow;
 
 namespace Server.Mobiles
 {
@@ -28,6 +29,13 @@ namespace Server.Mobiles
 			SetSkill( SkillName.Fencing, 75.0, 98.0 );
 			SetSkill( SkillName.Stealth, 85.0, 100.0 );
 			SetSkill( SkillName.RemoveTrap, 85.0, 100.0 );
+			AddItem( new Server.Items.Cloak() );
+			AddItem(new Server.Items.Artifact_ShadowBrokerArms());
+			AddItem(new Server.Items.Artifact_ShadowBrokerCap());
+			AddItem(new Server.Items.Artifact_ShadowBrokerGloves());
+			AddItem(new Server.Items.Artifact_ShadowBrokerGorget());
+			AddItem(new Server.Items.Artifact_ShadowBrokerLeggings());
+			AddItem(new Server.Items.Artifact_ShadowBrokerTunic());
 		}
 
 		public override void InitSBInfo( Mobile m )
@@ -35,6 +43,39 @@ namespace Server.Mobiles
 			m_Merchant = m;
 			SBInfos.Add( new MyStock() );
 		}
+
+		public override bool HandlesOnSpeech( Mobile from ) 
+		{ 
+			return true; 
+		} 
+
+        public override void OnSpeech(SpeechEventArgs e)
+        {
+            Mobile from = e.Mobile;
+
+            if (from == null || !(from is PlayerMobile))
+                return;
+          
+            if( e.Mobile.InRange( this, 4 ))
+			{
+			    if (e.Speech.IndexOf("reward") >= 0)
+                {
+					if (from is PlayerMobile && ((PlayerMobile)from).NpcGuild == NpcGuild.ThievesGuild)
+                    {
+                        from.SendGump(new Server.Custom.DefenderOfTheRealm.RewardGump(from, 3, 0));
+                        Say("These are the rewards I can offer you, friend.");
+                    }
+                    else
+                    {
+                        Say("I don't do business outside of the guild, friend.");
+                    }
+                }
+			    else 
+			    { 
+			        base.OnSpeech( e ); 
+			    }
+			}
+        }
 
 		public class MyStock: SBInfo
 		{
@@ -73,21 +114,6 @@ namespace Server.Mobiles
 			}
 		}
 
-		public override void InitOutfit()
-		{
-			base.InitOutfit();
-
-			int color = Utility.RandomNeutralHue();
-			switch ( Utility.RandomMinMax( 0, 5 ) )
-			{
-				case 0: AddItem( new Server.Items.Bandana( color ) ); break;
-				case 1: AddItem( new Server.Items.SkullCap( color ) ); break;
-				case 2: AddItem( new Server.Items.ClothCowl( color ) ); AddItem( new Server.Items.Cloak( color ) ); break;
-				case 3: AddItem( new Server.Items.ClothHood( color ) ); AddItem( new Server.Items.Cloak( color ) ); break;
-				case 4: AddItem( new Server.Items.FancyHood( color ) ); AddItem( new Server.Items.Cloak( color ) ); break;
-				case 5: AddItem( new Server.Items.HoodedMantle( color ) ); AddItem( new Server.Items.Cloak( color ) ); break;
-			}
-		}
 
 		public override void SayWelcomeTo( Mobile m )
 		{
@@ -271,82 +297,33 @@ namespace Server.Mobiles
 
 		    if (box is CommonContrabandBox)
 		    {
-		        int min = 50, max = 250;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new Gold(amount));
-		        GenerateEnchantedItem(mobile, 75, rewardBag);
-		        rewardBag.DropItem(Loot.RandomPotion(4, false));
+				VowRewardHelper.GenerateRewards( mobile, 5, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(10, 25)));
 		    }
 		    else if (box is UncommonContrabandBox)
 		    {
-		        int min = 250, max = 450;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new Gold(amount));
-		        GenerateEnchantedItem(mobile, 150, rewardBag);
-		        rewardBag.DropItem(Loot.RandomPotion(8, false));
+		    	VowRewardHelper.GenerateRewards( mobile, 10, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(35, 75)));
 		    }
 		    else if (box is RareContrabandBox)
 		    {
-		        int min = 550, max = 1090;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new Gold(amount));
-		        GenerateEnchantedItem(mobile, 200, rewardBag);
-
-		        if (Utility.Random(5) == 0)
-		            rewardBag.DropItem(PowerScroll.CreateRandom(5, 10));
-
-		        if (Utility.Random(5) == 0)
-		            rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 15));
-
-		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
-		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		        VowRewardHelper.GenerateRewards( mobile, 20, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(105, 145)));
 		    }
 		    else if (box is VeryRareContrabandBox)
 		    {
-		        int min = 1540, max = 2800;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new Gold(amount));
-				GenerateEnchantedItem(mobile, 300, rewardBag);
-		        if (Utility.RandomBool())
-		            rewardBag.DropItem(PowerScroll.CreateRandom(5, 10));
-		        else
-		            rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 15));
-
-		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
-		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+				VowRewardHelper.GenerateRewards( mobile, 30, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(185, 225)));
 		    }
 		    else if (box is ExtremelyRareContrabandBox)
 		    {
-		        int min = 3500, max = 6600;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new BankCheck(amount));
-				GenerateEnchantedItem(mobile, 400, rewardBag);
-		        rewardBag.DropItem(PowerScroll.CreateRandom(5, 15));
-		        rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 25));
-
-		        if (Utility.Random(5) == 0)
-		            rewardBag.DropItem(Loot.RandomArty());
-
-		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
-		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		        VowRewardHelper.GenerateRewards( mobile, 40, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(285, 345)));
 		    }
 		    else if (box is LegendaryContrabandBox)
 		    {
-		        int min = 10000, max = 12000;
-		        int amount = GetGoldByLuck(min, max, luck);
-		        rewardBag.DropItem(new BankCheck(amount));
-				GenerateEnchantedItem(mobile, 500, rewardBag);
-		        Item arty = Loot.RandomArty();
-		        
-				if (arty != null)
-		            rewardBag.DropItem(arty);
-
-		        rewardBag.DropItem(PowerScroll.CreateRandom(10, 20));
-		        rewardBag.DropItem(ScrollofTranscendence.CreateRandom(5, 35));
-		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
-		        rewardBag.DropItem(Loot.RandomRare(Utility.RandomMinMax(6, 12), mobile));
-		        rewardBag.DropItem(Loot.RandomRelic(mobile));
-		        rewardBag.DropItem(Loot.RandomRelic(mobile));
+		        VowRewardHelper.GenerateRewards( mobile, 50, rewardBag, VowType.Shadowbroker );
+				rewardBag.DropItem(new MarksOfTheShadowbroker(Utility.RandomMinMax(425, 500)));
 		    }
 		    mobile.AddToBackpack(rewardBag);
 			mobile.SendMessage("The Guildmaster rewards you for your skill and discretion.");
@@ -371,32 +348,5 @@ namespace Server.Mobiles
 			LoggingFunctions.LogStandard( mobile, "has smuggled a " + box.Name + "!" );
 
 		}
-
-		private static void GenerateEnchantedItem(Mobile from, int enchantLevel, Container rewardBag)
-        {
-            Item item = Loot.RandomMagicalItem(Server.LootPackEntry.playOrient(from));
-            if (item != null)
-            {
-                item = LootPackEntry.Enchant(from, enchantLevel, item);
-                rewardBag.DropItem(item);
-            }
-        }
-
-		private static int GetGoldByLuck(int min, int max, int luck)
-		{
-		    int randomValue = Utility.RandomMinMax(min, max);
-
-		    if (luck <= 0)
-		        return randomValue;
-
-		    if (luck >= 2000)
-		        return max;
-
-		    double luckFactor = Math.Min(luck, 2000) / 2000.0;
-		    int adjustedValue = min + (int)((max - min) * luckFactor);
-
-		    return Math.Max(randomValue, adjustedValue);
-		}
-
 	}
 }

--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -433,12 +433,17 @@ namespace Server.SkillHandlers
 				        if (from.CheckSkill(SkillName.Stealing, 0, 100))
 				        {
 				            Gold stolenGold = new Gold(gold);
+							int marks = gold/35 >= 1 ? gold/35 : 0;
 				            from.AddToBackpack(stolenGold);
 							from.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, string.Format("You successfully stole {0} gold.", gold));
 							from.SendMessage(string.Format("You successfully stole {0} gold.", gold));
-				            Titles.AwardKarma(from, -60, true);
-				            from.PlaySound(0x2E6); // Coin sound				
-
+				            if(from.Skills[SkillName.Snooping].Value > Utility.RandomMinMax(20, 126) && marks > 0)			
+							{
+								from.AddToBackpack(new MarksOfTheShadowbroker(marks));
+								from.SendMessage(string.Format("You gained {0} Marks of the Shadowbroker.", marks));
+							}
+							Titles.AwardKarma(from, -60, true);
+				            from.PlaySound(0x2E6); // Coin sound
 				            // Contraband check
 				            ContrabandSystem.TryGiveContraband(from, victim);
 				        }

--- a/Data/Scripts/System/Skills/Stealing.cs
+++ b/Data/Scripts/System/Skills/Stealing.cs
@@ -437,7 +437,7 @@ namespace Server.SkillHandlers
 				            from.AddToBackpack(stolenGold);
 							from.PublicOverheadMessage(MessageType.Regular, 0x3B2, false, string.Format("You successfully stole {0} gold.", gold));
 							from.SendMessage(string.Format("You successfully stole {0} gold.", gold));
-				            if(from.Skills[SkillName.Snooping].Value > Utility.RandomMinMax(20, 126) && marks > 0)			
+				            if(from.Skills[SkillName.Snooping].Value > Utility.RandomMinMax(20, 126) && marks > 0 && IsInGuild(from))			
 							{
 								from.AddToBackpack(new MarksOfTheShadowbroker(marks));
 								from.SendMessage(string.Format("You gained {0} Marks of the Shadowbroker.", marks));


### PR DESCRIPTION
this pr accomplishes the following:

- rewrites the 'vow' reward system to be more generic and easily expandable, so when new reward systems are implemented, they all can derive from the base logic.
- converts the thief contraband reward to the new system
- adds a new item, called 'marks of the shadowbroker', that thieves can get during regular gameplay and by handling in contraband to their guildmasters. 
- 
<img width="546" height="255" alt="image" src="https://github.com/user-attachments/assets/afe78f57-d336-4053-a94b-ceb09faa65dd" />

- adds half a dozen new chase artifacts for thieves themed around the shadowbroker set:
- 
<img width="322" height="427" alt="image" src="https://github.com/user-attachments/assets/5947c549-1687-41cf-8446-2123a480e36c" />

- makes it so that the thief guild master, the scourge and the defender of the realm are always wearing their reward artifacts, so players can actually see what they are getting. 
- adds a 'reward' speech handler to the thieves guildmaster that offer rewards derived from the common rewardpool, died accordingly

<img width="432" height="455" alt="image" src="https://github.com/user-attachments/assets/2c343757-5a0c-43fd-aed4-d2c7e00688cd" />


The purpose of this system is to make future improvements easier and generate a standard baseline of rewards over time. It also removes some of the extreme randomness from the old contraband system, and provides more steady progression. 
